### PR TITLE
windows: don't allow SDL to disable the screensaver

### DIFF
--- a/windows/src/main.rs
+++ b/windows/src/main.rs
@@ -70,6 +70,10 @@ fn run_flux(mode: Mode) -> Result<(), String> {
     #[cfg(windows)]
     set_dpi_awareness()?;
 
+    // By default, SDL disables the screensaver and doesn’t allow the display to sleep. We want
+    // both of these things to happen in both screensaver and preview modes.
+    sdl2::hint::set("SDL_VIDEO_ALLOW_SCREENSAVER", "1");
+
     let sdl_context = sdl2::init()?;
     let video_subsystem = sdl_context.video()?;
 
@@ -96,11 +100,6 @@ fn run_flux(mode: Mode) -> Result<(), String> {
 
     #[cfg(debug_assertions)]
     gl_attr.set_context_flags().debug().set();
-
-    // SDL, by default, disables the screensaver and doesn’t allow the display
-    // to sleep. We want both of these things to happen in both screensaver and
-    // preview modes.
-    video_subsystem.enable_screen_saver();
 
     let settings = Rc::new(Settings {
         mode: settings::Mode::Normal,


### PR DESCRIPTION
If SDL launches and disables the screensaver, Windows will reset the inactivity timer, further delaying display sleep.

Resolves #4.