### PR TITLE
Draw to a DXGI swapchain on Windows

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -12,11 +12,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1680584903,
-        "narHash": "sha256-uraq+D3jcLzw/UVk0xMHcnfILfIMa0DLrtAEq2nNlxU=",
+        "lastModified": 1684981077,
+        "narHash": "sha256-68X9cFm0RTZm8u0rXPbeBzOVUH5OoUGAfeHHVoxGd9o=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "65d3f6a3970cd46bef5eedfd458300f72c56b3c5",
+        "rev": "35110cccf28823320f4fd697fcafcb5038683982",
         "type": "github"
       },
       "original": {
@@ -58,16 +58,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1669062147,
-        "narHash": "sha256-h0RTwZg+cGlV3RlH9jXBHdyA9xQfbxo2oCn1zFieE2A=",
+        "lastModified": 1685716800,
+        "narHash": "sha256-b6RpYRRsv6Wwl9XG2sjLvqKdkPMvqQqgtiGJHAIyGSw=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b68bd2ee52051aaf983a268494cb4fc6c485b646",
+        "rev": "f3d743463920751eb092930d06e700981398332a",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "23.05-pre",
+        "ref": "nixos-23.05",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -92,11 +92,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1680488274,
-        "narHash": "sha256-0vYMrZDdokVmPQQXtFpnqA2wEgCCUXf5a3dDuDVshn0=",
+        "lastModified": 1683080331,
+        "narHash": "sha256-nGDvJ1DAxZIwdn6ww8IFwzoHb2rqBP4wv/65Wt5vflk=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "7ec2ff598a172c6e8584457167575b3a1a5d80d8",
+        "rev": "d59c3fa0cba8336e115b376c2d9e91053aa59e56",
         "type": "github"
       },
       "original": {
@@ -115,11 +115,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1680747499,
-        "narHash": "sha256-E9rcxSTsqRqNd4SD+D/4aqm3qfFyVw0S9YseCks7h+c=",
+        "lastModified": 1685759304,
+        "narHash": "sha256-I3YBH6MS3G5kGzNuc1G0f9uYfTcNY9NYoRc3QsykLk4=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "8ad3b5ee01a2074b54274216ff2cf0ab844a7426",
+        "rev": "c535b4f3327910c96dcf21851bbdd074d0760290",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,7 @@
   description = "Flux Screensavers";
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/23.05-pre";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-23.05";
     flake-utils.url = "github:numtide/flake-utils";
     crane = {
       url = "github:ipetkov/crane";

--- a/flake.nix
+++ b/flake.nix
@@ -65,13 +65,13 @@
       });
 
       SDL2_static = pkgs.SDL2.overrideAttrs (old: rec {
-        version = "2.26.4";
+        version = "2.26.5";
         name = "SDL2-static-${version}";
         src = builtins.fetchurl {
           url =
             "https://www.libsdl.org/release/${old.pname}-${version}.tar.gz";
           sha256 =
-            "sha256:0cbji2l35j5w9v5kkb9s16n6w03xg81kj2zqygcqlxpvk1j6h3qs";
+            "sha256:1xxbbvn0jmw5fgn26fyybc7xd3xsnjk67lxi8lychr5yl4yym3xd";
         };
         dontDisableStatic = true;
 

--- a/windows/Cargo.lock
+++ b/windows/Cargo.lock
@@ -4,9 +4,9 @@ version = 3
 
 [[package]]
 name = "ab_glyph"
-version = "0.2.20"
+version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe21446ad43aa56417a767f3e2f3d7c4ca522904de1dd640529a76e9c5c3b33c"
+checksum = "5110f1c78cf582855d895ecd0746b653db010cec6d9f5575293f27934d980a39"
 dependencies = [
  "ab_glyph_rasterizer",
  "owned_ttf_parser",
@@ -88,9 +88,9 @@ dependencies = [
 
 [[package]]
 name = "arrayref"
-version = "0.3.6"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4c527152e37cf757a3f78aae5a06fbeefdb07ccc535c980a3208ee3060dd544"
+checksum = "6b4930d2cb77ce62f89ee5d5289b4ac049559b1c45539271f5ed4fdc7db34545"
 
 [[package]]
 name = "arrayvec"
@@ -106,9 +106,9 @@ checksum = "8da52d66c7071e2e3fa2a1e5c6d088fec47b593032b254f5e980de8ea54454d6"
 
 [[package]]
 name = "ash"
-version = "0.37.2+1.3.238"
+version = "0.37.3+1.3.251"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28bf19c1f0a470be5fbf7522a308a05df06610252c5bcf5143e1b23f629a9a03"
+checksum = "39e9c3835d686b0a6084ab4234fcd1b07dbf6e4767dce60874b12356a25ecd4a"
 dependencies = [
  "libloading",
 ]
@@ -129,7 +129,7 @@ dependencies = [
  "cc",
  "cfg-if",
  "libc",
- "miniz_oxide",
+ "miniz_oxide 0.6.2",
  "object",
  "rustc-demangle",
 ]
@@ -151,9 +151,9 @@ checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
 
 [[package]]
 name = "bit_field"
-version = "0.10.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcb6dd1c2376d2e096796e234a70e17e94cc2d5d54ff8ce42b28cef1d0d359a4"
+checksum = "dc827186963e592360843fb5ba4b973e145841266c1357f7180c43526f2e5b61"
 
 [[package]]
 name = "bitflags"
@@ -188,28 +188,28 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.12.0"
+version = "3.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d261e256854913907f67ed06efbc3338dfe6179796deefc1ff763fc1aee5535"
+checksum = "a3e2c3daef883ecc1b5d58c15adae93470a91d425f3532ba1695849656af3fc1"
 
 [[package]]
 name = "bytemuck"
-version = "1.13.0"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c041d3eab048880cb0b86b256447da3f18859a163c3b8d8893f4e6368abe6393"
+checksum = "17febce684fd15d89027105661fec94afb475cb995fbc59d2865198446ba2eea"
 dependencies = [
  "bytemuck_derive",
 ]
 
 [[package]]
 name = "bytemuck_derive"
-version = "1.4.0"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1aca418a974d83d40a0c1f0c5cba6ff4bc28d8df099109ca459a2118d40b6322"
+checksum = "fdde5c9cd29ebd706ce1b35600920a33550e402fc998a2e53ad3b42c3c47a192"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.18",
 ]
 
 [[package]]
@@ -304,9 +304,9 @@ dependencies = [
 
 [[package]]
 name = "cmake"
-version = "0.1.49"
+version = "0.1.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db34956e100b30725f2eb215f90d4871051239535632f84fea3bc92722c66b7c"
+checksum = "a31c789563b815f77f4250caee12365734369f942439b7defd71e18a48197130"
 dependencies = [
  "cc",
 ]
@@ -329,9 +329,9 @@ dependencies = [
 
 [[package]]
 name = "cocoa-foundation"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ade49b65d560ca58c403a479bb396592b155c0185eada742ee323d1d68d6318"
+checksum = "931d3837c286f56e3c58423ce4eba12d08db2374461a785c86f672b08b5650d6"
 dependencies = [
  "bitflags",
  "block",
@@ -360,9 +360,9 @@ checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
 
 [[package]]
 name = "const_panic"
-version = "0.2.7"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58baae561b85ca19b3122a9ddd35c8ec40c3bcd14fe89921824eae73f7baffbf"
+checksum = "6051f239ecec86fde3410901ab7860d458d160371533842974fc61f96d15879b"
 
 [[package]]
 name = "core-foundation"
@@ -376,9 +376,9 @@ dependencies = [
 
 [[package]]
 name = "core-foundation-sys"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
+checksum = "e496a50fda8aacccc86d7529e2c1e0892dbd0f898a6b5645b5561b89c3210efa"
 
 [[package]]
 name = "core-graphics"
@@ -446,14 +446,14 @@ checksum = "2320c07ceb3e491e2bd09ade90a91c29a42d9553f1bde60c945cb5c34958b26e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.6"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2dd04ddaf88237dc3b8d8f9a3c1004b506b54b3313403944054d23c0870c521"
+checksum = "a33c2bf77f2df06183c3aa30d1e96c0695a313d4f9c453cc3762a6db39f99200"
 dependencies = [
  "cfg-if",
  "crossbeam-utils",
@@ -461,9 +461,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-deque"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "715e8152b692bba2d374b53d4875445368fdf21a94751410af607a5ac677d1fc"
+checksum = "ce6fd6f855243022dcecf8702fef0c297d4338e226845fe067f6341ad9fa0cef"
 dependencies = [
  "cfg-if",
  "crossbeam-epoch",
@@ -472,22 +472,22 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.13"
+version = "0.9.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01a9af1f4c2ef74bb8aa1f7e19706bc72d03598c8a570bb5de72243c7a9d9d5a"
+checksum = "46bd5f3f85273295a9d14aedfb86f6aadbff6d8f5295c4a9edb08e819dcf5695"
 dependencies = [
  "autocfg",
  "cfg-if",
  "crossbeam-utils",
- "memoffset 0.7.1",
+ "memoffset 0.8.0",
  "scopeguard",
 ]
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.14"
+version = "0.8.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fb766fa798726286dbbb842f174001dab8abc7b627a1dd86e0b7222a95d929f"
+checksum = "3c063cd8cc95f5c377ed0d4b49a4b21f632396ff690e8470c29b3359b346984b"
 dependencies = [
  "cfg-if",
 ]
@@ -559,7 +559,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -570,7 +570,7 @@ checksum = "9c972679f83bdf9c42bd905396b6c3588a843a17f0f16dfcfa3e2c5d57441835"
 dependencies = [
  "darling_core",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -684,7 +684,7 @@ checksum = "0f2f4de457d974f548d2c2a16f709ebd81013579e543bd1a9b19ced88132c2cf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -699,9 +699,9 @@ dependencies = [
 
 [[package]]
 name = "euclid"
-version = "0.22.7"
+version = "0.22.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b52c2ef4a78da0ba68fbe1fd920627411096d2ac478f7f4c9f3a54ba6705bade"
+checksum = "87f253bc5c813ca05792837a0ff4b3a580336b224512d48f7eda1d7dd9210787"
 dependencies = [
  "num-traits",
 ]
@@ -718,18 +718,27 @@ dependencies = [
 
 [[package]]
 name = "exr"
-version = "1.5.3"
+version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8af5ef47e2ed89d23d0ecbc1b681b30390069de70260937877514377fc24feb"
+checksum = "bdd2162b720141a91a054640662d3edce3d50a944a50ffca5313cd951abb35b4"
 dependencies = [
  "bit_field",
  "flume",
  "half",
  "lebe",
- "miniz_oxide",
+ "miniz_oxide 0.6.2",
+ "rayon-core",
  "smallvec",
- "threadpool",
  "zune-inflate",
+]
+
+[[package]]
+name = "fdeflate"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d329bdeac514ee06249dabc27877490f17f5d371ec693360768b838e19f3ae10"
+dependencies = [
+ "simd-adler32",
 ]
 
 [[package]]
@@ -743,12 +752,12 @@ dependencies = [
 
 [[package]]
 name = "flate2"
-version = "1.0.25"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8a2db397cb1c8772f31494cb8917e48cd1e64f0fa7efac59fbd741a0a8ce841"
+checksum = "3b9429470923de8e8cbd4d2dc513535400b4b3fef0319fb5c4e1f520a7bef743"
 dependencies = [
  "crc32fast",
- "miniz_oxide",
+ "miniz_oxide 0.7.1",
 ]
 
 [[package]]
@@ -783,7 +792,7 @@ dependencies = [
  "image",
  "log",
  "mint",
- "nalgebra 0.32.1",
+ "nalgebra 0.32.2",
  "rand",
  "rand_pcg",
  "rand_seeder",
@@ -799,14 +808,14 @@ dependencies = [
  "directories",
  "flux",
  "glow 0.12.2",
- "glutin 0.30.6",
+ "glutin 0.30.8",
  "iced",
  "log",
  "log-panics",
- "raw-window-handle 0.5.0",
+ "raw-window-handle 0.5.2",
  "sdl2",
  "sdl2-sys",
- "semver 1.0.16",
+ "semver 1.0.17",
  "serde",
  "serde_json",
  "simplelog",
@@ -867,13 +876,13 @@ dependencies = [
 
 [[package]]
 name = "foreign-types-macros"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8469d0d40519bc608ec6863f1cc88f3f1deee15913f2f3b3e573d81ed38cccc"
+checksum = "1a5c6c585bc94aaf2c7b51dd4c2ba22680844aba4c687be581871a6f518c5742"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.18",
 ]
 
 [[package]]
@@ -922,9 +931,9 @@ dependencies = [
 
 [[package]]
 name = "futures"
-version = "0.3.26"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13e2792b0ff0340399d58445b88fd9770e3489eff258a4cbc1523418f12abf84"
+checksum = "23342abe12aba583913b2e62f22225ff9c950774065e4bfb61a19cd9770fec40"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -937,9 +946,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.26"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e5317663a9089767a1ec00a487df42e0ca174b61b4483213ac24448e4664df5"
+checksum = "955518d47e09b25bbebc7a18df10b81f0c766eaf4c4f1cccef2fca5f2a4fb5f2"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -947,15 +956,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.26"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec90ff4d0fe1f57d600049061dc6bb68ed03c7d2fbd697274c41805dcb3f8608"
+checksum = "4bca583b7e26f571124fe5b7561d49cb2868d79116cfa0eefce955557c6fee8c"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.26"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8de0a35a6ab97ec8869e32a2473f4b1324459e14c29275d14b10cb1fd19b50e"
+checksum = "ccecee823288125bd88b4d7f565c9e58e41858e47ab72e8ea2d64e93624386e0"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -965,38 +974,38 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.26"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfb8371b6fb2aeb2d280374607aeabfc99d95c72edfe51692e42d3d7f0d08531"
+checksum = "4fff74096e71ed47f8e023204cfd0aa1289cd54ae5430a9523be060cdb849964"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.26"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95a73af87da33b5acf53acfebdc339fe592ecf5357ac7c0a7734ab9d8c876a70"
+checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.18",
 ]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.26"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f310820bb3e8cfd46c80db4d7fb8353e15dfff853a127158425f31e0be6c8364"
+checksum = "f43be4fe21a13b9781a69afa4985b0f6ee0e1afab2c6f454a8cf30e2b2237b6e"
 
 [[package]]
 name = "futures-task"
-version = "0.3.26"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcf79a1bf610b10f42aea489289c5a2c478a786509693b80cd39c44ccd936366"
+checksum = "76d3d132be6c0e6aa1534069c705a74a5997a356c0dc2f86a47765e5617c5b65"
 
 [[package]]
 name = "futures-util"
-version = "0.3.26"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c1d6de3acfef38d2be4b1f543f553131788603495be83da675e180c8d6b7bd1"
+checksum = "26b01e40b772d54cf6c6d721c1d1abd0647a0106a12ecaa1c186273392a69533"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1031,9 +1040,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.8"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c05aeb6a22b8f62540c194aac980f2115af067bfe15a0734d7277a768d396b31"
+checksum = "c85e1d9ab2eadba7e5040d4e09cbd6d072b76a557ad64e797c2cb9d4da21d7e4"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -1044,9 +1053,9 @@ dependencies = [
 
 [[package]]
 name = "gif"
-version = "0.11.4"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3edd93c6756b4dfaf2709eafcc345ba2636565295c198a9cfbf75fa5e3e00b06"
+checksum = "80792593675e051cf94a4b111980da2ba60d4a83e43e0048c5693baab3977045"
 dependencies = [
  "color_quant",
  "weezl",
@@ -1054,9 +1063,9 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.27.1"
+version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "221996f774192f0f718773def8201c4ae31f02616a54ccfc2d358bb0e5cefdec"
+checksum = "ad0a93d233ebf96623465aad4046a8d3aa4da22d4f4beba5388838c8a434bbb4"
 
 [[package]]
 name = "gl_generator"
@@ -1130,7 +1139,7 @@ dependencies = [
  "once_cell",
  "osmesa-sys",
  "parking_lot 0.12.1",
- "raw-window-handle 0.5.0",
+ "raw-window-handle 0.5.2",
  "wayland-client",
  "wayland-egl",
  "winapi",
@@ -1139,21 +1148,21 @@ dependencies = [
 
 [[package]]
 name = "glutin"
-version = "0.30.6"
+version = "0.30.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68dc39a51f661324ea93bf87066d62ee6e83439c4260332695478186ec318cac"
+checksum = "62f9b771a65f0a1e3ddb6aa16f867d87dc73c922411c255e6c4ab7f6d45c7327"
 dependencies = [
  "bitflags",
  "cfg_aliases",
  "cgl",
  "core-foundation",
  "dispatch",
- "glutin_egl_sys 0.4.0",
+ "glutin_egl_sys 0.5.0",
  "glutin_wgl_sys 0.4.0",
  "libloading",
  "objc2",
  "once_cell",
- "raw-window-handle 0.5.0",
+ "raw-window-handle 0.5.2",
  "windows-sys 0.45.0",
 ]
 
@@ -1169,9 +1178,9 @@ dependencies = [
 
 [[package]]
 name = "glutin_egl_sys"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5aaf0abb5c4148685b33101ae326a207946b4d3764d6cdc79f8316cdaa8367d"
+checksum = "1b3bcbddc51573b977fc6dca5d93867e4f29682cdbaf5d13e48f4fa4346d4d87"
 dependencies = [
  "gl_generator",
  "windows-sys 0.45.0",
@@ -1217,13 +1226,12 @@ dependencies = [
 
 [[package]]
 name = "glyph_brush"
-version = "0.7.5"
+version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac02497410cdb5062cc056a33f2e1e19ff69fbf26a4be9a02bf29d6e17ea105b"
+checksum = "4edefd123f28a0b1d41ec4a489c2b43020b369180800977801611084f342978d"
 dependencies = [
  "glyph_brush_draw_cache",
  "glyph_brush_layout",
- "log",
  "ordered-float",
  "rustc-hash",
  "twox-hash",
@@ -1256,9 +1264,9 @@ dependencies = [
 
 [[package]]
 name = "gpu-alloc"
-version = "0.5.3"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fc59e5f710e310e76e6707f86c561dd646f69a8876da9131703b2f717de818d"
+checksum = "22beaafc29b38204457ea030f6fb7a84c9e4dd1b86e311ba0542533453d87f62"
 dependencies = [
  "bitflags",
  "gpu-alloc-types",
@@ -1419,7 +1427,7 @@ dependencies = [
  "iced_native",
  "iced_style",
  "log",
- "raw-window-handle 0.5.0",
+ "raw-window-handle 0.5.2",
  "thiserror",
 ]
 
@@ -1464,7 +1472,7 @@ dependencies = [
  "iced_graphics",
  "iced_native",
  "log",
- "raw-window-handle 0.5.0",
+ "raw-window-handle 0.5.2",
  "wgpu",
  "wgpu_glyph",
 ]
@@ -1494,9 +1502,9 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "image"
-version = "0.24.5"
+version = "0.24.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69b7ea949b537b0fd0af141fff8c77690f2ce96f4f41f042ccb6c69c6c965945"
+checksum = "527909aa81e20ac3a44803521443a765550f09b5130c2c2fa1ea59c2f8f50a3a"
 dependencies = [
  "bytemuck",
  "byteorder",
@@ -1507,15 +1515,15 @@ dependencies = [
  "num-rational",
  "num-traits",
  "png",
- "scoped_threadpool",
+ "qoi",
  "tiff",
 ]
 
 [[package]]
 name = "indexmap"
-version = "1.9.2"
+version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1885e79c1fc4b10f0e172c475f458b7f7b93061064d98c3293e98c5ba0c8b399"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
 dependencies = [
  "autocfg",
  "hashbrown",
@@ -1535,9 +1543,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.5"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fad582f4b9e86b6caa621cabeb0963332d92eea04729ab12892c2533951e6440"
+checksum = "453ad9f582a441959e5f0d088b02ce04cfe8d51a8eaf077f12ac6d3e94164ca6"
 
 [[package]]
 name = "jni-sys"
@@ -1565,9 +1573,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.61"
+version = "0.3.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "445dde2150c55e483f3d8416706b97ec8e8237c307e5b7b4b8dd15e6af2a0730"
+checksum = "2f37a4a5928311ac501dee68b3c7613a1037d0edb30c8e5427bd832d55d1b790"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -1603,9 +1611,9 @@ checksum = "03087c2bad5e1034e8cace5926dec053fb3790248370865f5117a7d0213354c8"
 
 [[package]]
 name = "libc"
-version = "0.2.139"
+version = "0.2.144"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79"
+checksum = "2b00cc1c228a6782d0f076e7b232802e0c5689d41bb5df366f2a6b6621cfdfe1"
 
 [[package]]
 name = "libloading"
@@ -1635,11 +1643,10 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.17"
+version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
+checksum = "518ef76f2f87365916b142844c16d8fefd85039bc5699050210a7778ee1cd1de"
 dependencies = [
- "cfg-if",
  "serde",
 ]
 
@@ -1664,10 +1671,11 @@ dependencies = [
 
 [[package]]
 name = "matrixmultiply"
-version = "0.3.2"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "add85d4dd35074e6fedc608f8c8f513a3548619a9024b751949ef0e8e45a4d84"
+checksum = "090126dc04f95dc0d1c1c91f61bdd474b3930ca064c1edc8a849da2c6cbe1e77"
 dependencies = [
+ "autocfg",
  "rawpointer",
 ]
 
@@ -1679,9 +1687,9 @@ checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
 name = "memmap2"
-version = "0.5.8"
+version = "0.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b182332558b18d807c4ce1ca8ca983b34c3ee32765e47b3f0f69b90355cc1dc"
+checksum = "83faa42c0a078c393f6b29d5db232d8be22776a891f8f56e5284faee4a20b327"
 dependencies = [
  "libc",
 ]
@@ -1697,9 +1705,9 @@ dependencies = [
 
 [[package]]
 name = "memoffset"
-version = "0.7.1"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5de893c32cde5f383baa4c04c5d6dbdd735cfd4a794b0debdb2bb1b421da5ff4"
+checksum = "d61c719bcfbcf5d62b3a09efa6088de8c54bc0bfcd3ea7ae39fcc186108b8de1"
 dependencies = [
  "autocfg",
 ]
@@ -1734,6 +1742,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "miniz_oxide"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7810e0be55b428ada41041c41f32c9f1a42817901b4ccf45fa3d4b6561e74c7"
+dependencies = [
+ "adler",
+ "simd-adler32",
+]
+
+[[package]]
 name = "mint"
 version = "0.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1741,14 +1759,14 @@ checksum = "e53debba6bda7a793e5f99b8dacf19e626084f525f7829104ba9898f367d85ff"
 
 [[package]]
 name = "mio"
-version = "0.8.5"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5d732bc30207a6423068df043e3d02e0735b155ad7ce1a6f76fe2baa5b158de"
+checksum = "927a765cd3fc26206e66b296465fa9d3e5ab003e651c1b3c060e7956d96b19d2"
 dependencies = [
  "libc",
  "log",
  "wasi",
- "windows-sys 0.42.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1790,9 +1808,9 @@ dependencies = [
 
 [[package]]
 name = "nalgebra"
-version = "0.32.1"
+version = "0.32.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6515c882ebfddccaa73ead7320ca28036c4bc84c9bcca3cc0cbba8efe89223a"
+checksum = "d68d47bba83f9e2006d117a9a33af1524e655516b8919caac694427a6fb1e511"
 dependencies = [
  "approx",
  "matrixmultiply",
@@ -1801,7 +1819,7 @@ dependencies = [
  "num-complex",
  "num-rational",
  "num-traits",
- "simba 0.8.0",
+ "simba 0.8.1",
  "typenum",
 ]
 
@@ -1813,7 +1831,7 @@ checksum = "01fcc0b8149b4632adc89ac3b7b31a12fb6099a0317a4eb2ebff574ef7de7218"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1824,7 +1842,7 @@ checksum = "d232c68884c0c99810a5a4d333ef7e47689cfd0edc85efc9e54e1e6bf5212766"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1846,7 +1864,7 @@ dependencies = [
  "jni-sys",
  "ndk-sys",
  "num_enum",
- "raw-window-handle 0.5.0",
+ "raw-window-handle 0.5.2",
  "thiserror",
 ]
 
@@ -1882,7 +1900,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1943,15 +1961,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "nom8"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae01545c9c7fc4486ab7debaf2aad7003ac19431791868fb2e8066df97fad2f8"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "num-complex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2002,23 +2011,23 @@ dependencies = [
 
 [[package]]
 name = "num_enum"
-version = "0.5.9"
+version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d829733185c1ca374f17e52b762f24f535ec625d2cc1f070e34c8a9068f341b"
+checksum = "1f646caf906c20226733ed5b1374287eb97e3c2a5c227ce668c1f2ce20ae57c9"
 dependencies = [
  "num_enum_derive",
 ]
 
 [[package]]
 name = "num_enum_derive"
-version = "0.5.9"
+version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2be1598bf1c313dcdd12092e3f1920f463462525a21b7b4e11b4168353d0123e"
+checksum = "dcbff9bc912032c62bf65ef1d5aea88983b420f4f839db1e9b0c281a25c9c799"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -2059,9 +2068,9 @@ checksum = "df3b9834c1e95694a05a828b59f55fa2afec6288359cda67146126b3f90a55d7"
 
 [[package]]
 name = "objc2"
-version = "0.3.0-beta.3"
+version = "0.3.0-beta.3.patch-leaks.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe31e5425d3d0b89a15982c024392815da40689aceb34bad364d58732bcfd649"
+checksum = "7e01640f9f2cb1220bbe80325e179e532cb3379ebcd1bf2279d703c19fe3a468"
 dependencies = [
  "block2",
  "objc-sys",
@@ -2106,27 +2115,24 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.17.0"
+version = "1.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f61fba1741ea2b3d6a1e3178721804bb716a68a6aeba1149b5d52e3d464ea66"
+checksum = "9670a07f94779e00908f3e686eab508878ebb390ba6e604d3a284c00e8d0487b"
 
 [[package]]
 name = "orbclient"
-version = "0.3.43"
+version = "0.3.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "974465c5e83cf9df05c1e4137b271d29035c902e39e5ad4c1939837e22160af8"
+checksum = "221d488cd70617f1bd599ed8ceb659df2147d9393717954d82a0f5e8032a6ab1"
 dependencies = [
- "cfg-if",
- "redox_syscall 0.2.16",
- "wasm-bindgen",
- "web-sys",
+ "redox_syscall 0.3.5",
 ]
 
 [[package]]
 name = "ordered-float"
-version = "3.4.0"
+version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d84eb1409416d254e4a9c8fa56cc24701755025b458f0fcd8e59e1f5f40c23bf"
+checksum = "2fc2dbde8f8a79f2102cc474ceb0ad68e3b80b85289ea62389b60e66777e4213"
 dependencies = [
  "num-traits",
 ]
@@ -2142,9 +2148,9 @@ dependencies = [
 
 [[package]]
 name = "owned_ttf_parser"
-version = "0.18.1"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e25e9fb15717794fae58ab55c26e044103aad13186fbb625893f9a3bbcc24228"
+checksum = "706de7e2214113d63a8238d1910463cfce781129a6f263d13fdb09ff64355ba4"
 dependencies = [
  "ttf-parser",
 ]
@@ -2170,7 +2176,7 @@ dependencies = [
  "find-crate",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -2223,9 +2229,9 @@ dependencies = [
 
 [[package]]
 name = "paste"
-version = "1.0.11"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d01a5bd0424d00070b0098dd17ebca6f961a959dead1dbcbbbc1d1cd8d3deeba"
+checksum = "9f746c4065a8fa3fe23974dd82f15431cc8d40779821001404d10d2e79ca7d79"
 
 [[package]]
 name = "pathfinder_geometry"
@@ -2254,9 +2260,9 @@ checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
 
 [[package]]
 name = "pest"
-version = "2.5.5"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "028accff104c4e513bad663bbcd2ad7cfd5304144404c31ed0a77ac103d00660"
+checksum = "e68e84bfb01f0507134eac1e9b410a12ba379d064eab48c50ba4ce329a527b70"
 dependencies = [
  "thiserror",
  "ucd-trie",
@@ -2292,7 +2298,7 @@ dependencies = [
  "phf_shared",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -2306,22 +2312,22 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "1.0.12"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad29a609b6bcd67fee905812e544992d216af9d755757c05ed2d0e15a74c6ecc"
+checksum = "c95a7476719eab1e366eaf73d0260af3021184f18177925b07f54b30089ceead"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.0.12"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "069bdb1e05adc7a8990dce9cc75370895fbe4e3d58b9b73bf1aee56359344a55"
+checksum = "39407670928234ebc5e6e580247dd567ad73a3578460c5990f9503df207e8f07"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.18",
 ]
 
 [[package]]
@@ -2338,20 +2344,21 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkg-config"
-version = "0.3.26"
+version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ac9a59f73473f1b8d852421e59e64809f025994837ef743615c6d0c5b305160"
+checksum = "26072860ba924cbfa98ea39c8c19b4dd6a4a25423dbdf219c1eca91aa0cf6964"
 
 [[package]]
 name = "png"
-version = "0.17.7"
+version = "0.17.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d708eaf860a19b19ce538740d2b4bdeeb8337fa53f7738455e706623ad5c638"
+checksum = "aaeebc51f9e7d2c150d3f3bfeb667f2aa985db5ef1e3d212847bdedb488beeaa"
 dependencies = [
  "bitflags",
  "crc32fast",
+ "fdeflate",
  "flate2",
- "miniz_oxide",
+ "miniz_oxide 0.7.1",
 ]
 
 [[package]]
@@ -2362,9 +2369,9 @@ checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
 name = "proc-macro-crate"
-version = "1.3.0"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66618389e4ec1c7afe67d51a9bf34ff9236480f8d51e7489b7d5ab0303c13f34"
+checksum = "7f4c021e1093a56626774e81216a4ce732a735e5bad4868a03f3ed65ca0c3919"
 dependencies = [
  "once_cell",
  "toml_edit",
@@ -2372,24 +2379,33 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.51"
+version = "1.0.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d727cae5b39d21da60fa540906919ad737832fe0b1c165da3a34d6548c849d6"
+checksum = "6aeca18b86b413c660b781aa319e4e2648a3e6f9eadc9b47e9038e6fe9f3451b"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "profiling"
-version = "1.0.7"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74605f360ce573babfe43964cbe520294dcb081afbf8c108fc6e23036b4da2df"
+checksum = "332cd62e95873ea4f41f3dfd6bbbfc5b52aec892d7e8d534197c4720a0bbbab2"
+
+[[package]]
+name = "qoi"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f6d64c71eb498fe9eae14ce4ec935c555749aef511cca85b5568910d6e48001"
+dependencies = [
+ "bytemuck",
+]
 
 [[package]]
 name = "quote"
-version = "1.0.23"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8856d8364d252a14d474036ea1358d63c9e6965c8e5c1885c18f73d70bff9c7b"
+checksum = "1b9ab9c7eadfd8df19006f1cf1a4aed13540ed5cbc047010ece5826e10825488"
 dependencies = [
  "proc-macro2",
 ]
@@ -2469,12 +2485,9 @@ dependencies = [
 
 [[package]]
 name = "raw-window-handle"
-version = "0.5.0"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed7e3d950b66e19e0c372f3fa3fbbcf85b1746b571f74e0c2af6042a5c93420a"
-dependencies = [
- "cty",
-]
+checksum = "f2ff9a1f06a88b01621b7ae906ef0211290d1c8a168a15542486a8f61c0833b9"
 
 [[package]]
 name = "rawpointer"
@@ -2484,9 +2497,9 @@ checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
 
 [[package]]
 name = "rayon"
-version = "1.6.1"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db3a213adf02b3bcfd2d3846bb41cb22857d131789e01df434fb7e7bc0759b7"
+checksum = "1d2df5196e37bcc87abebc0053e20787d73847bb33134a69841207dd0a47f03b"
 dependencies = [
  "either",
  "rayon-core",
@@ -2494,9 +2507,9 @@ dependencies = [
 
 [[package]]
 name = "rayon-core"
-version = "1.10.2"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "356a0625f1954f730c0201cdab48611198dc6ce21f4acff55089b5a78e6e835b"
+checksum = "4b8f95bd6966f5c87776639160a66bd8ab9895d9d4ab01ddba9fc60661aebe8d"
 dependencies = [
  "crossbeam-channel",
  "crossbeam-deque",
@@ -2541,9 +2554,9 @@ checksum = "f1382d1f0a252c4bf97dc20d979a2fdd05b024acd7c2ed0f7595d7817666a157"
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.21"
+version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ef03e0a2b150c7a90d01faf6254c9c48a41e95fb2a8c2ac1c6f0d2b9aefc342"
+checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
 
 [[package]]
 name = "rustc-hash"
@@ -2562,9 +2575,9 @@ dependencies = [
 
 [[package]]
 name = "ryu"
-version = "1.0.12"
+version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b4b9743ed687d4b4bcedf9ff5eaa7398495ae14e61cba0a295704edbc7decde"
+checksum = "f91339c0467de62360649f8d3e185ca8de4224ff281f66000de5eb2a77a79041"
 
 [[package]]
 name = "safe_arch"
@@ -2600,12 +2613,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
 
 [[package]]
-name = "scoped_threadpool"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d51f5df5af43ab3f1360b429fa5e0152ac5ce8c0bd6485cae490332e96846a8"
-
-[[package]]
 name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2626,19 +2633,19 @@ dependencies = [
 [[package]]
 name = "sdl2"
 version = "0.35.2"
-source = "git+https://github.com/Rust-SDL2/rust-sdl2?branch=master#0c4fb75bc4797147241ccd4ae2a52717908b785b"
+source = "git+https://github.com/Rust-SDL2/rust-sdl2?branch=master#27cd1fd67c811e06b9d997a77bb6089a1b65070d"
 dependencies = [
  "bitflags",
  "lazy_static",
  "libc",
- "raw-window-handle 0.5.0",
+ "raw-window-handle 0.5.2",
  "sdl2-sys",
 ]
 
 [[package]]
 name = "sdl2-sys"
 version = "0.35.2"
-source = "git+https://github.com/Rust-SDL2/rust-sdl2?branch=master#0c4fb75bc4797147241ccd4ae2a52717908b785b"
+source = "git+https://github.com/Rust-SDL2/rust-sdl2?branch=master#27cd1fd67c811e06b9d997a77bb6089a1b65070d"
 dependencies = [
  "cfg-if",
  "libc",
@@ -2656,9 +2663,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.16"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58bc9567378fc7690d6b2addae4e60ac2eeea07becb2c64b9f218b53865cba2a"
+checksum = "bebd363326d05ec3e2f532ab7660680f3b02130d780c299bca73469d521bc0ed"
 dependencies = [
  "serde",
 ]
@@ -2674,29 +2681,29 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.152"
+version = "1.0.163"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb7d1f0d3021d347a83e556fc4683dea2ea09d87bccdf88ff5c12545d89d5efb"
+checksum = "2113ab51b87a539ae008b5c6c02dc020ffa39afd2d83cffcb3f4eb2722cebec2"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.152"
+version = "1.0.163"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af487d118eecd09402d70a5d72551860e788df87b464af30e5ea6a38c75c541e"
+checksum = "8c805777e3930c8883389c602315a24224bcc738b63905ef87cd1420353ea93e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.18",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.93"
+version = "1.0.96"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cad406b69c91885b5107daf2c29572f6c8cdb3c66826821e286c533490c0bc76"
+checksum = "057d394a50403bcac12672b2b18fb387ab6d289d957dab67dd201875391e52f1"
 dependencies = [
  "itoa",
  "ryu",
@@ -2749,9 +2756,9 @@ dependencies = [
 
 [[package]]
 name = "simba"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50582927ed6f77e4ac020c057f37a268fc6aebc29225050365aacbb9deeeddc4"
+checksum = "061507c94fc6ab4ba1c9a0305018408e312e17c041eb63bef8aa726fa33aceae"
 dependencies = [
  "approx",
  "num-complex",
@@ -2762,15 +2769,15 @@ dependencies = [
 
 [[package]]
 name = "simd-adler32"
-version = "0.3.4"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14a5df39617d7c8558154693a1bb8157a4aab8179209540cc0b10e5dc24e0b18"
+checksum = "238abfbb77c1915110ad968465608b68e869e0772622c9656714e73e5a1a522f"
 
 [[package]]
 name = "simplelog"
-version = "0.12.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48dfff04aade74dd495b007c831cd6f4e0cee19c344dd9dc0884c0289b70a786"
+checksum = "acee08041c5de3d5048c8b3f6f13fafb3026b24ba43c6a695a0c76179b844369"
 dependencies = [
  "log",
  "termcolor",
@@ -2785,9 +2792,9 @@ checksum = "7bd3e3206899af3f8b12af284fafc038cc1dc2b41d1b89dd17297221c5d225de"
 
 [[package]]
 name = "slab"
-version = "0.4.7"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4614a76b2a8be0058caa9dbbaf66d988527d86d003c11a94fbd335d7661edcef"
+checksum = "6528351c9bc8ab22353f9d776db39a20288e8d6c37ef8cfe3317cf875eecfc2d"
 dependencies = [
  "autocfg",
 ]
@@ -2838,9 +2845,9 @@ dependencies = [
 
 [[package]]
 name = "spin"
-version = "0.9.5"
+version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dccf47db1b41fa1573ed27ccf5e08e3ca771cb994f776668c5ebda893b248fc"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 dependencies = [
  "lock_api",
 ]
@@ -2881,9 +2888,20 @@ checksum = "8fb1df15f412ee2e9dfc1c504260fa695c1c3f10fe9f4a6ee2d2184d7d6450e2"
 
 [[package]]
 name = "syn"
-version = "1.0.107"
+version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f4064b5b16e03ae50984a5a8ed5d4f8803e6bc1fd170a3cda91a1be4b18e3f5"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32d41677bcbe24c20c52e7c70b0d8db04134c5d1066bf98662e2871ad200ea3e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2901,31 +2919,22 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.38"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a9cd18aa97d5c45c6603caea1da6628790b37f7a34b6ca89522331c5180fed0"
+checksum = "978c9a314bd8dc99be594bc3c175faaa9794be04a5a5e153caba6915336cebac"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.38"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fb327af4685e4d03fa8cbcf1716380da910eeb2bb8be417e7f9fd3fb164f36f"
+checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
-]
-
-[[package]]
-name = "threadpool"
-version = "1.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d050e60b33d41c19108b32cea32164033a9013fe3b46cbd4457559bfbf77afaa"
-dependencies = [
- "num_cpus",
+ "syn 2.0.18",
 ]
 
 [[package]]
@@ -2941,9 +2950,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.17"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a561bf4617eebd33bca6434b988f39ed798e527f51a1e797d0ee4f61c0a38376"
+checksum = "8f3403384eaacbca9923fa06940178ac13e4edb725486d70e8e15881d0c836cc"
 dependencies = [
  "itoa",
  "libc",
@@ -2955,15 +2964,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e153e1f1acaef8acc537e68b44906d2db6436e2b35ac2c6b42640fff91f00fd"
+checksum = "7300fbefb4dadc1af235a9cef3737cea692a9d97e1b9cbcd4ebdae6f8868e6fb"
 
 [[package]]
 name = "time-macros"
-version = "0.2.6"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d967f99f534ca7e495c575c62638eebc2898a8c84c119b89e250477bc4ba16b2"
+checksum = "372950940a5f07bf38dbe211d7283c9e6d7327df53794992d293e534c733d09b"
 dependencies = [
  "time-core",
 ]
@@ -3004,26 +3013,26 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "0.5.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4553f467ac8e3d374bc9a177a26801e5d0f9b211aa1673fb137a403afd1c9cf5"
+checksum = "5a76a9312f5ba4c2dec6b9161fdf25d87ad8a09256ccea5a556fef03c706a10f"
 
 [[package]]
 name = "toml_edit"
-version = "0.18.1"
+version = "0.19.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56c59d8dd7d0dcbc6428bf7aa2f0e823e26e43b3c9aca15bbc9475d23e5fa12b"
+checksum = "2380d56e8670370eee6566b0bfd4265f65b3f432e8c6d85623f728d4fa31f739"
 dependencies = [
  "indexmap",
- "nom8",
  "toml_datetime",
+ "winnow",
 ]
 
 [[package]]
 name = "ttf-parser"
-version = "0.18.1"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0609f771ad9c6155384897e1df4d948e692667cc0588548b68eb44d052b27633"
+checksum = "44dcf002ae3b32cd25400d6df128c5babec3927cd1eb7ce813cfff20eb6c3746"
 
 [[package]]
 name = "twox-hash"
@@ -3050,9 +3059,9 @@ checksum = "9e79c4d996edb816c91e4308506774452e55e95c3c9de07b6729e17e15a5ef81"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.6"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84a22b9f218b40614adcb3f4ff08b703773ad44fa9423e4e0d346d5db86e4ebc"
+checksum = "b15811caf2415fb889178633e7724bad2509101cde276048e013b9def5e51fa0"
 
 [[package]]
 name = "unicode-segmentation"
@@ -3092,12 +3101,11 @@ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "walkdir"
-version = "2.3.2"
+version = "2.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "808cf2735cd4b6866113f648b791c6adc5714537bc222d9347bb203386ffda56"
+checksum = "36df944cda56c7d8d8b7496af378e6b16de9284591917d307c9b4d313c44e698"
 dependencies = [
  "same-file",
- "winapi",
  "winapi-util",
 ]
 
@@ -3109,9 +3117,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.84"
+version = "0.2.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31f8dcbc21f30d9b8f2ea926ecb58f6b91192c17e9d33594b3df58b2007ca53b"
+checksum = "5bba0e8cb82ba49ff4e229459ff22a191bbe9a1cb3a341610c9c33efc27ddf73"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -3119,24 +3127,24 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.84"
+version = "0.2.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95ce90fd5bcc06af55a641a86428ee4229e44e07033963a2290a8e241607ccb9"
+checksum = "19b04bc93f9d6bdee709f6bd2118f57dd6679cf1176a1af464fca3ab0d66d8fb"
 dependencies = [
  "bumpalo",
  "log",
  "once_cell",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.18",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.34"
+version = "0.4.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f219e0d211ba40266969f6dbdd90636da12f75bee4fc9d6c23d1260dadb51454"
+checksum = "2d1985d03709c53167ce907ff394f5316aa22cb4e12761295c5dc57dacb6297e"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -3146,9 +3154,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.84"
+version = "0.2.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c21f77c0bedc37fd5dc21f897894a5ca01e7bb159884559461862ae90c0b4c5"
+checksum = "14d6b024f1a526bb0234f52840389927257beb670610081360e5a03c5df9c258"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -3156,22 +3164,22 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.84"
+version = "0.2.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2aff81306fcac3c7515ad4e177f521b5c9a15f2b08f4e32d823066102f35a5f6"
+checksum = "e128beba882dd1eb6200e1dc92ae6c5dbaa4311aa7bb211ca035779e5efc39f8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.18",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.84"
+version = "0.2.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0046fef7e28c3804e5e38bfa31ea2a0f73905319b677e57ebe37e49358989b5d"
+checksum = "ed9d5b4305409d1fc9482fee2d7f9bcbf24b3972bf59817ef757e23982242a93"
 
 [[package]]
 name = "wasm-timer"
@@ -3273,9 +3281,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.61"
+version = "0.3.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e33b99f4b23ba3eec1a53ac264e35a755f00e966e0065077d6027c0f575b0b97"
+checksum = "3bdd9ef4e984da1187bf8110c5cf5b845fbc87a23602cdf912386a76fcd3a7c2"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -3298,7 +3306,7 @@ dependencies = [
  "log",
  "naga",
  "parking_lot 0.12.1",
- "raw-window-handle 0.5.0",
+ "raw-window-handle 0.5.2",
  "smallvec",
  "static_assertions",
  "wasm-bindgen",
@@ -3325,7 +3333,7 @@ dependencies = [
  "naga",
  "parking_lot 0.12.1",
  "profiling",
- "raw-window-handle 0.5.0",
+ "raw-window-handle 0.5.2",
  "smallvec",
  "thiserror",
  "web-sys",
@@ -3362,7 +3370,7 @@ dependencies = [
  "parking_lot 0.12.1",
  "profiling",
  "range-alloc",
- "raw-window-handle 0.5.0",
+ "raw-window-handle 0.5.2",
  "renderdoc-sys",
  "smallvec",
  "thiserror",
@@ -3395,9 +3403,9 @@ dependencies = [
 
 [[package]]
 name = "wide"
-version = "0.7.6"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "feff0a412894d67223777b6cc8d68c0dab06d52d95e9890d5f2d47f10dd9366c"
+checksum = "5cd0496a71f3cc6bc4bf0ed91346426a5099e93d89807e663162dc5a1069ff65"
 dependencies = [
  "bytemuck",
  "safe_arch 0.6.0",
@@ -3481,26 +3489,20 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.42.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
-dependencies = [
- "windows_aarch64_gnullvm 0.42.2",
- "windows_aarch64_msvc 0.42.2",
- "windows_i686_gnu 0.42.2",
- "windows_i686_msvc 0.42.2",
- "windows_x86_64_gnu 0.42.2",
- "windows_x86_64_gnullvm 0.42.2",
- "windows_x86_64_msvc 0.42.2",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
 dependencies = [
  "windows-targets 0.42.2",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.0",
 ]
 
 [[package]]
@@ -3669,7 +3671,7 @@ dependencies = [
  "parking_lot 0.12.1",
  "percent-encoding",
  "raw-window-handle 0.4.3",
- "raw-window-handle 0.5.0",
+ "raw-window-handle 0.5.2",
  "sctk-adwaita",
  "smithay-client-toolkit",
  "wasm-bindgen",
@@ -3698,12 +3700,21 @@ dependencies = [
  "objc2",
  "once_cell",
  "orbclient",
- "raw-window-handle 0.5.0",
+ "raw-window-handle 0.5.2",
  "redox_syscall 0.3.5",
  "wasm-bindgen",
  "wayland-scanner",
  "web-sys",
  "windows-sys 0.45.0",
+]
+
+[[package]]
+name = "winnow"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61de7bac303dc551fe038e2b3cef0f571087a47571ea6e79a87692ac99b99699"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -3763,15 +3774,15 @@ checksum = "a67300977d3dc3f8034dae89778f502b6ba20b269527b3223ba59c0cf393bb8a"
 
 [[package]]
 name = "xml-rs"
-version = "0.8.4"
+version = "0.8.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2d7d3948613f75c98fd9328cfdcc45acc4d360655289d0a7d4ec931392200a3"
+checksum = "52839dc911083a8ef63efa4d039d1f58b5e409f923e44c80828f206f66e5541c"
 
 [[package]]
 name = "zune-inflate"
-version = "0.2.50"
+version = "0.2.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "589245df6230839c305984dcc0a8385cc72af1fd223f360ffd5d65efa4216d40"
+checksum = "73ab332fe2f6680068f3582b16a24f90ad7096d5d39b974d1c0aff0125116f02"
 dependencies = [
  "simd-adler32",
 ]

--- a/windows/Cargo.lock
+++ b/windows/Cargo.lock
@@ -772,13 +772,13 @@ dependencies = [
 
 [[package]]
 name = "flux"
-version = "4.4.0"
-source = "git+https://github.com/sandydoo/flux?branch=main#8c064670a60726acebe82dfe36465aaae69c18ef"
+version = "4.5.0"
+source = "git+https://github.com/sandydoo/flux?branch=main#09c45ee7ecf243cba0e481bf12a7e74d53bb731d"
 dependencies = [
  "bytemuck",
  "crevice",
  "getrandom",
- "glow",
+ "glow 0.12.2",
  "half",
  "image",
  "log",
@@ -798,7 +798,7 @@ version = "1.4.0"
 dependencies = [
  "directories",
  "flux",
- "glow",
+ "glow 0.12.2",
  "glutin 0.30.6",
  "iced",
  "log",
@@ -1088,13 +1088,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "glow"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "807edf58b70c0b5b2181dd39fe1839dbdb3ba02645630dc5f753e23da307f762"
+dependencies = [
+ "js-sys",
+ "slotmap",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
 name = "glow_glyph"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0f4e62c64947b9a24fe20e2bba9ad819ecb506ef5c8df7ffc4737464c6df9510"
 dependencies = [
  "bytemuck",
- "glow",
+ "glow 0.11.2",
  "glyph_brush",
  "log",
 ]
@@ -1373,7 +1385,7 @@ checksum = "95755f62fec2ec2c8f8bc2c0be5072b1d0dfed8db250686059ddcce5da530acf"
 dependencies = [
  "bytemuck",
  "euclid",
- "glow",
+ "glow 0.11.2",
  "glow_glyph",
  "glyph_brush",
  "iced_graphics",
@@ -3337,7 +3349,7 @@ dependencies = [
  "d3d12",
  "foreign-types 0.3.2",
  "fxhash",
- "glow",
+ "glow 0.11.2",
  "gpu-alloc",
  "gpu-descriptor",
  "js-sys",

--- a/windows/Cargo.lock
+++ b/windows/Cargo.lock
@@ -359,6 +359,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
 
 [[package]]
+name = "com-rs"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf43edc576402991846b093a7ca18a3477e0ef9c588cde84964b5d3e43016642"
+
+[[package]]
 name = "const_panic"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -529,9 +535,9 @@ checksum = "b365fabc795046672053e29c954733ec3b05e4be654ab130fe8f1f94d7051f35"
 
 [[package]]
 name = "d3d12"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "827914e1f53b1e0e025ecd3d967a7836b7bcb54520f90e21ef8df7b4d88a2759"
+checksum = "d8f0de2f5a8e7bd4a9eec0e3c781992a4ce1724f68aec7d7a3715344de8b39da"
 dependencies = [
  "bitflags",
  "libloading",
@@ -575,9 +581,9 @@ dependencies = [
 
 [[package]]
 name = "directories"
-version = "4.0.1"
+version = "5.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f51c5d4ddabd36886dd3e1438cb358cdcb0d7c499cb99cb4ac2e38e18b5cb210"
+checksum = "9a49173b84e034382284f27f1af4dcbbd231ffa358c0fe316541a7337f376a35"
 dependencies = [
  "dirs-sys",
 ]
@@ -594,13 +600,14 @@ dependencies = [
 
 [[package]]
 name = "dirs-sys"
-version = "0.3.7"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b1d1d91c932ef41c0f2663aa8b0ca0342d444d842c06914aa0a7e352d0bada6"
+checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
 dependencies = [
  "libc",
+ "option-ext",
  "redox_users",
- "winapi",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -819,7 +826,7 @@ dependencies = [
  "serde",
  "serde_json",
  "simplelog",
- "windows",
+ "windows 0.48.0",
  "winit 0.28.3",
  "winres",
 ]
@@ -1282,6 +1289,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "gpu-allocator"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce95f9e2e11c2c6fadfce42b5af60005db06576f231f5c92550fdded43c423e8"
+dependencies = [
+ "backtrace",
+ "log",
+ "thiserror",
+ "winapi",
+ "windows 0.44.0",
+]
+
+[[package]]
 name = "gpu-descriptor"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1331,6 +1351,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "hassle-rs"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90601c6189668c7345fc53842cb3f3a3d872203d523be1b3cb44a36a3e62fb85"
+dependencies = [
+ "bitflags",
+ "com-rs",
+ "libc",
+ "libloading",
+ "thiserror",
+ "widestring",
+ "winapi",
+]
+
+[[package]]
 name = "hermit-abi"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1347,9 +1382,9 @@ checksum = "dfa686283ad6dd069f105e5ab091b04c62850d3e4cf5d67debad1933f55023df"
 
 [[package]]
 name = "iced"
-version = "0.7.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df71e87f8211b57a439d0764131d2c421a9195036dd4b6608033b05f2f16c196"
+checksum = "efbddf356d01e9d41cd394a9d04d62bfd89650a30f12fda5839cabb8c4591c88"
 dependencies = [
  "iced_core",
  "iced_futures",
@@ -1364,9 +1399,9 @@ dependencies = [
 
 [[package]]
 name = "iced_core"
-version = "0.7.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ade666613eb8b621971a59cfae9e11ec051f32afc5ed4d8e8915d5abfaf2cee"
+checksum = "11e1942e28dedee756cc27e67e7a838cdc1e59fb6bf9627ec9f709ab3b135782"
 dependencies = [
  "bitflags",
  "instant",
@@ -1375,9 +1410,9 @@ dependencies = [
 
 [[package]]
 name = "iced_futures"
-version = "0.5.1"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cc3a9fd79b857228dde2a3e923a04ade4095abeda33248c6230e8c909749366"
+checksum = "215d51fa4f70dbb63775d7141243c4d98d4d525d8949695601f8fbac7dcbc04e"
 dependencies = [
  "futures",
  "log",
@@ -1387,9 +1422,9 @@ dependencies = [
 
 [[package]]
 name = "iced_glow"
-version = "0.6.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95755f62fec2ec2c8f8bc2c0be5072b1d0dfed8db250686059ddcce5da530acf"
+checksum = "adc5b081015f5c75777c96ad75e2288916e7d444c97396d6d136517877ef9129"
 dependencies = [
  "bytemuck",
  "euclid",
@@ -1403,9 +1438,9 @@ dependencies = [
 
 [[package]]
 name = "iced_glutin"
-version = "0.6.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccd8dd58586541b300b280b6fe8605add7a90283dfb8e622adc96cc545f5fa61"
+checksum = "5c427ca018d29508512581d832fbaa7b6c8ec34c39d438f35f59e363a6419953"
 dependencies = [
  "glutin 0.29.1",
  "iced_graphics",
@@ -1416,9 +1451,9 @@ dependencies = [
 
 [[package]]
 name = "iced_graphics"
-version = "0.6.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54177b85fdae36a8a1a4f052a5c65c5006565dc27f1feead13eeeed10fd0975a"
+checksum = "338a6aff7db906537074ad0fe8b720cfdb9512cdfea43c628c76bd1cf50fdcc0"
 dependencies = [
  "bitflags",
  "bytemuck",
@@ -1433,23 +1468,24 @@ dependencies = [
 
 [[package]]
 name = "iced_native"
-version = "0.8.0"
+version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79d57c8e8672e90c55d4f9f55511b03e5a74af9d296be9693e9c07cd9eed4563"
+checksum = "d012eb06da490fe46a695b39721c20da9643f35cf2ecb9d30618fdeb96170616"
 dependencies = [
  "iced_core",
  "iced_futures",
  "iced_style",
  "num-traits",
+ "thiserror",
  "twox-hash",
  "unicode-segmentation",
 ]
 
 [[package]]
 name = "iced_style"
-version = "0.6.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b992f5e1828c61af3661fc0e7bf141ef5284007a41fa6667c5e79d047a03daf4"
+checksum = "0e37333dc2991201140302cd0d4cea051bd37ca3671d5008ec85df86d232ff30"
 dependencies = [
  "iced_core",
  "once_cell",
@@ -1458,9 +1494,9 @@ dependencies = [
 
 [[package]]
 name = "iced_wgpu"
-version = "0.8.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4bb296363d1b18d4f57e1c69bb19591405e61d47764e43078bba31c6689fca5"
+checksum = "478803c56061f567ce5ddf223b20d11d3c118cc46bb0d0552370dc65cdc4cb9c"
 dependencies = [
  "bitflags",
  "bytemuck",
@@ -1479,9 +1515,9 @@ dependencies = [
 
 [[package]]
 name = "iced_winit"
-version = "0.7.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d528f882781c5594cb3d2416fe18787b4364e0cdd39f03d077ccc0becac1f9bd"
+checksum = "8a59ea3a85149a6a1f9e92b6c740ce90f04e5c7d848cfd05742336863fceb955"
 dependencies = [
  "iced_futures",
  "iced_graphics",
@@ -1771,9 +1807,9 @@ dependencies = [
 
 [[package]]
 name = "naga"
-version = "0.10.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "262d2840e72dbe250e8cf2f522d080988dfca624c4112c096238a4845f591707"
+checksum = "6c3d4269bcb7d50121097702fde1afb75f4ea8083aeb7a55688dcf289a853271"
 dependencies = [
  "bit-set",
  "bitflags",
@@ -2118,6 +2154,12 @@ name = "once_cell"
 version = "1.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9670a07f94779e00908f3e686eab508878ebb390ba6e604d3a284c00e8d0487b"
+
+[[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "orbclient"
@@ -3297,15 +3339,17 @@ checksum = "9193164d4de03a926d909d3bc7c30543cecb35400c02114792c2cae20d5e2dbb"
 
 [[package]]
 name = "wgpu"
-version = "0.14.2"
+version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81f643110d228fd62a60c5ed2ab56c4d5b3704520bd50561174ec4ec74932937"
+checksum = "d745a1b6d91d85c33defbb29f0eee0450e1d2614d987e14bf6baf26009d132d7"
 dependencies = [
  "arrayvec 0.7.2",
+ "cfg-if",
  "js-sys",
  "log",
  "naga",
  "parking_lot 0.12.1",
+ "profiling",
  "raw-window-handle 0.5.2",
  "smallvec",
  "static_assertions",
@@ -3319,14 +3363,13 @@ dependencies = [
 
 [[package]]
 name = "wgpu-core"
-version = "0.14.2"
+version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6000d1284ef8eec6076fd5544a73125fd7eb9b635f18dceeb829d826f41724ca"
+checksum = "7131408d940e335792645a98f03639573b0480e9e2e7cddbbab74f7c6d9f3fff"
 dependencies = [
  "arrayvec 0.7.2",
  "bit-vec",
  "bitflags",
- "cfg_aliases",
  "codespan-reporting",
  "fxhash",
  "log",
@@ -3343,9 +3386,9 @@ dependencies = [
 
 [[package]]
 name = "wgpu-hal"
-version = "0.14.1"
+version = "0.15.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cc320a61acb26be4f549c9b1b53405c10a223fbfea363ec39474c32c348d12f"
+checksum = "bdcf61a283adc744bb5453dd88ea91f3f86d5ca6b027661c6c73c7734ae0288b"
 dependencies = [
  "android_system_properties",
  "arrayvec 0.7.2",
@@ -3357,11 +3400,14 @@ dependencies = [
  "d3d12",
  "foreign-types 0.3.2",
  "fxhash",
- "glow 0.11.2",
+ "glow 0.12.2",
  "gpu-alloc",
+ "gpu-allocator",
  "gpu-descriptor",
+ "hassle-rs",
  "js-sys",
  "khronos-egl",
+ "libc",
  "libloading",
  "log",
  "metal",
@@ -3382,18 +3428,20 @@ dependencies = [
 
 [[package]]
 name = "wgpu-types"
-version = "0.14.1"
+version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb6b28ef22cac17b9109b25b3bf8c9a103eeb293d7c5f78653979b09140375f6"
+checksum = "32444e121b0bd00cb02c0de32fde457a9491bd44e03e7a5db6df9b1da2f6f110"
 dependencies = [
  "bitflags",
+ "js-sys",
+ "web-sys",
 ]
 
 [[package]]
 name = "wgpu_glyph"
-version = "0.18.0"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cafb82773e0f124a33674dab5de4dff73175aeb921949047ab014efb58fb446"
+checksum = "e25440d5f32ec39de49c57c15c2d3f9133a7939b069b5ad07e5afd8b78fb8adc"
 dependencies = [
  "bytemuck",
  "glyph_brush",
@@ -3410,6 +3458,12 @@ dependencies = [
  "bytemuck",
  "safe_arch 0.6.0",
 ]
+
+[[package]]
+name = "widestring"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17882f045410753661207383517a6f62ec3dbeb6a4ed2acce01f0728238d1983"
 
 [[package]]
 name = "winapi"
@@ -3463,6 +3517,15 @@ dependencies = [
  "clipboard_x11",
  "raw-window-handle 0.3.4",
  "thiserror",
+]
+
+[[package]]
+name = "windows"
+version = "0.44.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e745dab35a0c4c77aa3ce42d595e13d2003d6902d6b08c9ef5fc326d08da12b"
+dependencies = [
+ "windows-targets 0.42.2",
 ]
 
 [[package]]

--- a/windows/Cargo.toml
+++ b/windows/Cargo.toml
@@ -25,7 +25,7 @@ strip = true # Remove debug symbols
 
 [dependencies]
 directories = "4"
-glow = "0.11.2"
+glow = "0.12.2"
 log = { version = "0.4", features = ["serde"] }
 log-panics = { version = "2", features = ["with-backtrace"]}
 raw-window-handle = "0.5"
@@ -40,12 +40,6 @@ git = "https://github.com/sandydoo/winit"
 branch = "flux"
 default-features = false
 
-# [target.'cfg(not(windows))'.dependencies.sdl2]
-# version = "0.35.2"
-# default-features = false
-# features = [ "use-pkgconfig", "raw-window-handle" ]
-
-# [target.'cfg(windows)'.dependencies.sdl2]
 [dependencies.sdl2]
 version = "0.35.2"
 default-features = false
@@ -80,16 +74,22 @@ branch = "main"
 version =  "^0.48.0"
 features = [
   "Win32_Foundation",
+  "Win32_Graphics_Direct3D",
+  "Win32_Graphics_Direct3D11",
   "Win32_Graphics_Dwm",
+  "Win32_Graphics_Dxgi",
+  "Win32_Graphics_Dxgi_Common",
   "Win32_Graphics_Gdi",
+  "Win32_Graphics_OpenGL",
   "Win32_System_Com",
   "Win32_System_LibraryLoader",
+  "Win32_System_Threading",
   "Win32_UI_HiDpi",
   "Win32_UI_Shell",
   "Win32_UI_WindowsAndMessaging"
 ]
 
-[build-dependencies]
+[target.'cfg(windows)'.build-dependencies]
 winres = "0.1.12"
 
 [patch.crates-io]

--- a/windows/Cargo.toml
+++ b/windows/Cargo.toml
@@ -89,7 +89,7 @@ features = [
   "Win32_UI_WindowsAndMessaging"
 ]
 
-[target.'cfg(windows)'.build-dependencies]
+[build-dependencies]
 winres = "0.1.12"
 
 [patch.crates-io]

--- a/windows/Cargo.toml
+++ b/windows/Cargo.toml
@@ -24,7 +24,7 @@ panic = "abort" # Strip expensive panic unwinding code
 strip = true # Remove debug symbols
 
 [dependencies]
-directories = "4"
+directories = "5"
 glow = "0.12.2"
 log = { version = "0.4", features = ["serde"] }
 log-panics = { version = "2", features = ["with-backtrace"]}
@@ -55,7 +55,7 @@ default-features = false
 features = ["egl", "wgl"]
 
 [dependencies.iced]
-version = "0.7"
+version = "0.9"
 default-features = false
 features = [
    # Use system fonts

--- a/windows/build.rs
+++ b/windows/build.rs
@@ -9,7 +9,6 @@ fn main() {
     }
 
     // Skip windres in development.
-    #[cfg(windows)]
     if env("PROFILE") == "release" {
         let mut resource = winres::WindowsResource::new();
 

--- a/windows/build.rs
+++ b/windows/build.rs
@@ -9,6 +9,7 @@ fn main() {
     }
 
     // Skip windres in development.
+    #[cfg(windows)]
     if env("PROFILE") == "release" {
         let mut resource = winres::WindowsResource::new();
 

--- a/windows/src/gl_context.rs
+++ b/windows/src/gl_context.rs
@@ -34,13 +34,11 @@ pub(crate) fn new_gl_context(
     raw_display_handle: RawDisplayHandle,
     inner_size: PhysicalSize<u32>,
 
-    hidden_window: Option<RawWindowHandle>,
+    raw_window_handle: RawWindowHandle,
     // A hack to create the gl_display using the invisible event window
     // we create for the preview.
     attr_window: Option<RawWindowHandle>,
 ) -> GLContext {
-    let raw_window_handle = hidden_window.unwrap();
-
     let template = ConfigTemplateBuilder::new()
         .with_buffer_type(glutin::config::ColorBufferType::Rgb {
             r_size: 8,

--- a/windows/src/gl_context.rs
+++ b/windows/src/gl_context.rs
@@ -1,0 +1,205 @@
+use crate::winit_compat::NonZeroU32PhysicalSize;
+
+use std::ffi::CString;
+use std::fmt;
+use std::rc::Rc;
+
+use raw_window_handle::{RawDisplayHandle, RawWindowHandle};
+use winit::dpi::PhysicalSize;
+use winit::window::Window;
+
+use glow as GL;
+use glow::HasContext;
+use glutin::config::{ColorBufferType, Config as GLConfig, ConfigTemplateBuilder};
+use glutin::context::{ContextApi, ContextAttributesBuilder, PossiblyCurrentContext, Version};
+use glutin::display::{Display, DisplayApiPreference, GetGlDisplay};
+use glutin::prelude::*;
+use glutin::surface::{Surface, SurfaceAttributesBuilder, WindowSurface};
+
+pub struct GLContext {
+    pub context: PossiblyCurrentContext,
+    pub surface: Surface<WindowSurface>,
+    pub gl: Rc<glow::Context>,
+    pub window: Option<Window>,
+}
+
+/// Create an OpenGL context, surface, and initialize the glow API.
+///
+/// Hacks
+///
+/// The optional attr_window should be used when rendering to the preview window. Instead of just
+/// using the handle to the preview window, pass the window handle for the invisible event window
+/// to work around a bug where Windows complains that it can't find the window class.
+///
+/// This code has been modified from glutin-winit and only supports WGL (Windows).
+pub(crate) fn new_gl_context(
+    raw_display_handle: RawDisplayHandle,
+    actual_raw_window_handle: RawWindowHandle,
+    inner_size: PhysicalSize<u32>,
+
+    hidden_window: Option<RawWindowHandle>,
+    // A hack to create the gl_display using the invisible event window
+    // we create for the preview.
+    attr_window: Option<RawWindowHandle>,
+) -> GLContext {
+    let raw_window_handle = hidden_window.unwrap();
+
+    let template = ConfigTemplateBuilder::new()
+        .with_buffer_type(glutin::config::ColorBufferType::Rgb {
+            r_size: 8,
+            g_size: 8,
+            b_size: 8,
+        })
+        .with_alpha_size(8)
+        .with_transparency(true)
+        .compatible_with_native_window(raw_window_handle)
+        .build();
+
+    // Only WGL requires a window to create a full-fledged OpenGL context
+    let attr_window = attr_window.unwrap_or(raw_window_handle);
+    let preference = DisplayApiPreference::WglThenEgl(Some(attr_window));
+    let gl_display = unsafe { Display::new(raw_display_handle, preference).unwrap() };
+
+    // Rank the configs by transparency and alpha size, while prefering the original order of the
+    // configs.
+    #[derive(Debug, Eq, Ord, PartialEq, PartialOrd)]
+    struct Rank {
+        supports_transparency: bool,
+        alpha_size: u8,
+        samples: i8,
+        prefer_original_order: isize,
+    }
+
+    let (gl_config_index, gl_config) = unsafe {
+        gl_display
+            .find_configs(template)
+            .unwrap()
+            .enumerate()
+            .map(|(index, config)| {
+                log::debug!("Found config #{index}:\n{}", HumanConfig::new(&config));
+                (index, config)
+            })
+            .max_by_key(|(index, config)| Rank {
+                supports_transparency: config.supports_transparency().unwrap_or(false),
+                alpha_size: config.alpha_size(),
+                samples: -(config.num_samples() as i8),
+                prefer_original_order: -(*index as isize),
+            })
+            .expect("cannot find a suitable GL config")
+    };
+
+    log::debug!(
+        "Picked config #{gl_config_index}:\n{}",
+        HumanConfig::new(&gl_config)
+    );
+
+    // Request the minimum required OpenGL version for Flux
+    let context_attributes = ContextAttributesBuilder::new()
+        .with_context_api(ContextApi::OpenGl(Some(Version::new(3, 3))))
+        .build(Some(raw_window_handle));
+
+    // Fallback to GLES 3.0 (aka WebGL 2.0)
+    let fallback_context_attributes = ContextAttributesBuilder::new()
+        .with_context_api(ContextApi::Gles(Some(Version::new(3, 0))))
+        .build(Some(raw_window_handle));
+
+    let not_current_gl_context = unsafe {
+        gl_display
+            .create_context(&gl_config, &context_attributes)
+            .unwrap_or_else(|_| {
+                gl_display
+                    .create_context(&gl_config, &fallback_context_attributes)
+                    .expect("failed to create OpenGL context")
+            })
+    };
+
+    let (width, height) = inner_size.non_zero().expect("non-zero window size").into();
+    let attrs =
+        SurfaceAttributesBuilder::<WindowSurface>::new().build(raw_window_handle, width, height);
+
+    let gl_surface = unsafe {
+        gl_config
+            .display()
+            .create_window_surface(&gl_config, &attrs)
+            .unwrap()
+    };
+
+    // Make it current.
+    let gl_context = not_current_gl_context.make_current(&gl_surface).unwrap();
+
+    let glow_context = unsafe {
+        glow::Context::from_loader_function(|s| {
+            gl_display.get_proc_address(&CString::new(s).unwrap().as_c_str()) as *const _
+        })
+    };
+    log::debug!("{:?}", glow_context.version());
+
+    // Set common GL state
+    unsafe {
+        glow_context.disable(GL::MULTISAMPLE);
+    }
+
+    GLContext {
+        context: gl_context,
+        surface: gl_surface,
+        gl: Rc::new(glow_context),
+        window: None,
+    }
+}
+
+#[derive(Debug)]
+struct HumanConfig {
+    color_buffer_type: Option<ColorBufferType>,
+    alpha_size: u8,
+    depth_size: u8,
+    stencil_size: u8,
+    float_pixels: bool,
+    srgb_capable: bool,
+    supports_transparency: bool,
+    num_samples: u8,
+    hardware_accelerated: bool,
+}
+
+impl HumanConfig {
+    fn new(config: &GLConfig) -> Self {
+        Self {
+            color_buffer_type: config.color_buffer_type(),
+            alpha_size: config.alpha_size(),
+            depth_size: config.depth_size(),
+            stencil_size: config.stencil_size(),
+            float_pixels: config.float_pixels(),
+            srgb_capable: config.srgb_capable(),
+            supports_transparency: config.supports_transparency().unwrap_or(false),
+            num_samples: config.num_samples(),
+            hardware_accelerated: config.hardware_accelerated(),
+        }
+    }
+}
+
+impl fmt::Display for HumanConfig {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let HumanConfig {
+            color_buffer_type,
+            alpha_size,
+            depth_size,
+            stencil_size,
+            float_pixels,
+            srgb_capable,
+            supports_transparency,
+            num_samples,
+            hardware_accelerated,
+        } = self;
+        write!(
+            f,
+            "Color buffer type: {color_buffer_type:?}\n\
+               Alpha size: {alpha_size}\n\
+               Depth size: {depth_size}\n\
+               Stencil size: {stencil_size}\n\
+               Float pixels: {float_pixels}\n\
+               sRGB capable: {srgb_capable}\n\
+               Supports transparency: {supports_transparency}\n\
+               Number of samples: {num_samples}\n\
+               Hardware accelerated: {hardware_accelerated}"
+        )
+    }
+}

--- a/windows/src/gl_context.rs
+++ b/windows/src/gl_context.rs
@@ -20,7 +20,6 @@ pub struct GLContext {
     pub context: PossiblyCurrentContext,
     pub surface: Surface<WindowSurface>,
     pub gl: Rc<glow::Context>,
-    pub window: Option<Window>,
 }
 
 /// Create an OpenGL context, surface, and initialize the glow API.
@@ -34,7 +33,6 @@ pub struct GLContext {
 /// This code has been modified from glutin-winit and only supports WGL (Windows).
 pub(crate) fn new_gl_context(
     raw_display_handle: RawDisplayHandle,
-    actual_raw_window_handle: RawWindowHandle,
     inner_size: PhysicalSize<u32>,
 
     hidden_window: Option<RawWindowHandle>,
@@ -113,7 +111,7 @@ pub(crate) fn new_gl_context(
             })
     };
 
-    let (width, height) = inner_size.non_zero().expect("non-zero window size").into();
+    let (width, height) = inner_size.non_zero().expect("non-zero window size");
     let attrs =
         SurfaceAttributesBuilder::<WindowSurface>::new().build(raw_window_handle, width, height);
 
@@ -129,7 +127,7 @@ pub(crate) fn new_gl_context(
 
     let glow_context = unsafe {
         glow::Context::from_loader_function(|s| {
-            gl_display.get_proc_address(&CString::new(s).unwrap().as_c_str()) as *const _
+            gl_display.get_proc_address(CString::new(s).unwrap().as_c_str()) as *const _
         })
     };
     log::debug!("{:?}", glow_context.version());
@@ -143,7 +141,6 @@ pub(crate) fn new_gl_context(
         context: gl_context,
         surface: gl_surface,
         gl: Rc::new(glow_context),
-        window: None,
     }
 }
 

--- a/windows/src/gl_context.rs
+++ b/windows/src/gl_context.rs
@@ -6,7 +6,6 @@ use std::rc::Rc;
 
 use raw_window_handle::{RawDisplayHandle, RawWindowHandle};
 use winit::dpi::PhysicalSize;
-use winit::window::Window;
 
 use glow as GL;
 use glow::HasContext;

--- a/windows/src/gl_context.rs
+++ b/windows/src/gl_context.rs
@@ -132,6 +132,8 @@ pub(crate) fn new_gl_context(
     // Set common GL state
     unsafe {
         glow_context.disable(GL::MULTISAMPLE);
+        // glow_context.disable(GL::STENCIL_TEST);
+        // glow_context.disable(GL::DEPTH_TEST);
     }
 
     GLContext {

--- a/windows/src/main.rs
+++ b/windows/src/main.rs
@@ -50,12 +50,12 @@ const FADE_TO_BLACK_DURATION: f64 = 300.0;
 
 type WindowId = u32;
 
+#[allow(dead_code)]
 struct Instance {
     flux: Flux,
     window: Window,
 
     gl_context: gl_context::GLContext,
-    #[allow(dead_code)]
     gl_window: Option<Window>,
 
     swapchain: Swapchain,
@@ -396,7 +396,7 @@ fn new_preview_window(
     let gl_context = gl_context::new_gl_context(
         window.raw_display_handle(),
         inner_size,
-        None,
+        raw_window_handle,
         Some(window.raw_window_handle()),
     );
 
@@ -460,8 +460,7 @@ fn new_instance(
     let gl_context = gl_context::new_gl_context(
         window.raw_display_handle(),
         window.size().into(),
-        Some(hidden_window.raw_window_handle()),
-        // Some(window.raw_window_handle()),
+        hidden_window.raw_window_handle(),
         None,
     );
 

--- a/windows/src/main.rs
+++ b/windows/src/main.rs
@@ -183,7 +183,7 @@ fn init_logging(optional_log_dir: Option<&path::Path>) {
     use simplelog::*;
 
     let mut loggers: Vec<Box<dyn SharedLogger>> = vec![TermLogger::new(
-        LevelFilter::Debug,
+        LevelFilter::Warn,
         Config::default(),
         TerminalMode::Mixed,
         ColorChoice::Auto,

--- a/windows/src/main.rs
+++ b/windows/src/main.rs
@@ -295,27 +295,6 @@ fn new_preview_window(
 
     let inner_size = PhysicalSize::new(rect.right as u32, rect.bottom as u32);
 
-    // Tell SDL that the window we’re about to adopt will be used with
-    // OpenGL.
-    sdl2::hint::set("SDL_VIDEO_FOREIGN_WINDOW_OPENGL", "1");
-    let sdl_preview_window: *mut sdl2_sys::SDL_Window =
-        unsafe { sdl2_sys::SDL_CreateWindowFrom(win32_handle.hwnd as _) };
-
-    if sdl_preview_window.is_null() {
-        return Err(format!(
-            "Can’t create the preview window with the handle {:?}",
-            win32_handle.hwnd
-        ));
-    }
-
-    let preview_window: Window = unsafe {
-        Window::from_ll(
-            video_subsystem.clone(),
-            sdl_preview_window,
-            std::ptr::null_mut(),
-        )
-    };
-
     // You need to create an actual window to listen to events. We’ll
     // then link this to the preview window as a child to cleanup when
     // the preview dialog is closed.

--- a/windows/src/main.rs
+++ b/windows/src/main.rs
@@ -412,7 +412,7 @@ fn new_instance(
 ) -> Result<Instance, String> {
     // Create the SDL window
     let window = video_subsystem
-        .window("Flux", surface.size.width, surface.size.height + 1)
+        .window("Flux", surface.size.width, surface.size.height)
         .position(surface.position.x, surface.position.y)
         .input_grabbed()
         .borderless()

--- a/windows/src/main.rs
+++ b/windows/src/main.rs
@@ -133,6 +133,7 @@ impl Instance {
             self.flux.render();
 
             self.gl.bind_framebuffer(GL::FRAMEBUFFER, None);
+
             self.gl.finish();
 
             (self.dxgi_interop.dx_interop.DXUnlockObjectsNV)(
@@ -309,7 +310,6 @@ fn run_main_loop(
                 }
                 | Event::KeyDown { .. }
                 | Event::MouseButtonDown { .. } => {
-                    log::debug!("EVENT");
                     break 'main;
                 }
 
@@ -985,7 +985,7 @@ fn create_dxgi_swapchain(
         //     WGL_ACCESS_READ_WRITE_DISCARD_NV,
         // );
 
-        // According to my testing, AMD graphics cards don't support sharig renderbuffers.
+        // According to my testing, AMD graphics cards don't support sharing renderbuffers.
         let color_handle_gl = (dx_interop.DXRegisterObjectNV)(
             gl_handle_d3d,
             color_buffer.as_raw(),
@@ -1050,10 +1050,11 @@ fn create_dxgi_swapchain(
     }
 }
 
+use windows::Win32::Graphics::Direct3D11::ID3D11RenderTargetView;
 use windows::Win32::Graphics::Direct3D11::{
     ID3D11Device, ID3D11DeviceContext, D3D11_CREATE_DEVICE_DEBUG,
 };
-use windows::Win32::Graphics::Dxgi::{IDXGISwapChain, IDXGISwapChain2};
+use windows::Win32::Graphics::Dxgi::IDXGISwapChain2;
 
 struct DXGIInterop {
     device: ID3D11Device,

--- a/windows/src/main.rs
+++ b/windows/src/main.rs
@@ -3,6 +3,8 @@
 
 mod cli;
 mod config;
+mod gl_context;
+mod platform;
 mod settings_window;
 mod surface;
 mod wallpaper;
@@ -11,32 +13,22 @@ mod winit_compat;
 use cli::Mode;
 use config::Config;
 use flux::Flux;
-use windows::Win32::Graphics::Dxgi::Common::DXGI_FORMAT_B8G8R8A8_UNORM;
 use winit_compat::{HasMonitors, HasWinitWindow, MonitorHandle};
 
 use std::collections::HashMap;
-use std::ffi::CString;
-use std::num::NonZeroU32;
-use std::{fmt, fs, mem, path, process, rc::Rc};
+use std::{fs, path, process, rc::Rc};
 
 use glow as GL;
 use glow::HasContext;
+use glutin::context::PossiblyCurrentContextGlSurfaceAccessor;
 
-use raw_window_handle::{
-    HasRawDisplayHandle, HasRawWindowHandle, RawDisplayHandle, RawWindowHandle,
-};
+use raw_window_handle::{HasRawDisplayHandle, HasRawWindowHandle, RawWindowHandle};
 
 #[cfg(windows)]
 use windows::Win32::Foundation::HWND;
 
 use sdl2::video::Window;
 use winit::dpi::PhysicalSize;
-
-use glutin::config::{ColorBufferType, Config as GLConfig, ConfigTemplateBuilder};
-use glutin::context::{ContextApi, ContextAttributesBuilder, PossiblyCurrentContext, Version};
-use glutin::display::{Display, DisplayApiPreference, GetGlDisplay};
-use glutin::prelude::*;
-use glutin::surface::{Surface, SurfaceAttributesBuilder, SwapInterval, WindowSurface};
 
 // http://developer.download.nvidia.com/devzone/devcenter/gamegraphics/files/OptimusRenderingPolicies.pdf
 #[cfg(target_os = "windows")]
@@ -50,99 +42,69 @@ pub static mut NvOptimusEnablement: i32 = 1;
 #[no_mangle]
 pub static mut AmdPowerXpressRequestHighPerformance: i32 = 1;
 
+// Higher values will make the screensaver tolerate more mouse movement before exiting.
 const MINIMUM_MOUSE_MOTION_TO_EXIT_SCREENSAVER: f64 = 10.0;
-
-// In milliseconds
+// In milliseconds. TODO: likely doesn't work on most platforms
 const FADE_TO_BLACK_DURATION: f64 = 300.0;
 
 type WindowId = u32;
 
 struct Instance {
     flux: Flux,
-    gl_context: PossiblyCurrentContext,
-    gl_surface: Surface<WindowSurface>,
-    gl: Rc<glow::Context>,
-    gl_window: Option<Window>,
     window: Window,
-    dxgi_interop: DXGIInterop,
+
+    gl_context: gl_context::GLContext,
+
+    // DXGI swapchain
+    #[cfg(windows)]
+    dxgi_interop: platform::windows::dxgi_swapchain::DXGIInterop,
 }
 
 impl Instance {
     pub fn draw(&mut self, timestamp: f64) {
         unsafe {
-            use windows::Win32::System::Threading::{WaitForSingleObject, INFINITE};
-            WaitForSingleObject(self.dxgi_interop.frame_latency_waitable_object, INFINITE);
+            platform::windows::dxgi_swapchain::with_dxgi_swapchain(&mut self.dxgi_interop, |fbo| {
+                self.gl_context
+                    .context
+                    .make_current(&self.gl_context.surface)
+                    .expect("make OpenGL context current");
 
-            (self.dxgi_interop.dx_interop.DXLockObjectsNV)(
-                self.dxgi_interop.gl_handle_d3d,
-                1,
-                &mut self.dxgi_interop.color_handle_gl as *mut _,
-            );
+                self.flux.compute(timestamp);
 
-            self.gl_context
-                .make_current(&self.gl_surface)
-                .expect("make OpenGL context current");
+                #[cfg(windows)]
+                self.gl_context
+                    .gl
+                    .bind_framebuffer(GL::FRAMEBUFFER, Some(*fbo));
 
-            self.flux.compute(timestamp);
+                self.flux.render();
 
-            self.gl
-                .bind_framebuffer(GL::FRAMEBUFFER, Some(self.dxgi_interop.fbo));
+                self.gl_context.gl.bind_framebuffer(GL::FRAMEBUFFER, None);
 
-            self.flux.render();
-
-            self.gl.bind_framebuffer(GL::FRAMEBUFFER, None);
-
-            self.gl.finish();
-
-            (self.dxgi_interop.dx_interop.DXUnlockObjectsNV)(
-                self.dxgi_interop.gl_handle_d3d,
-                1,
-                &mut self.dxgi_interop.color_handle_gl as *mut _,
-            );
-
-            let _ = self.dxgi_interop.swap_chain.Present(1, 0);
+                self.gl_context.gl.finish();
+            });
         }
-
-        // self.gl_surface
-        //     .swap_buffers(&self.gl_context)
-        //     .expect("swap OpenGL buffers");
     }
 
     pub fn fade_to_black(&mut self, timestamp: f64) {
         unsafe {
-            use windows::Win32::System::Threading::{WaitForSingleObject, INFINITE};
-            WaitForSingleObject(self.dxgi_interop.frame_latency_waitable_object, INFINITE);
+            platform::windows::dxgi_swapchain::with_dxgi_swapchain(&mut self.dxgi_interop, |fbo| {
+                self.gl_context
+                    .context
+                    .make_current(&self.gl_context.surface)
+                    .expect("make OpenGL context current");
 
-            (self.dxgi_interop.dx_interop.DXLockObjectsNV)(
-                self.dxgi_interop.gl_handle_d3d,
-                1,
-                &mut self.dxgi_interop.color_handle_gl as *mut _,
-            );
+                #[cfg(windows)]
+                self.gl_context
+                    .gl
+                    .bind_framebuffer(GL::FRAMEBUFFER, Some(*fbo));
 
-            self.gl_context
-                .make_current(&self.gl_surface)
-                .expect("make OpenGL context current");
+                let progress = (timestamp / FADE_TO_BLACK_DURATION).clamp(0.0, 1.0) as f32;
+                self.gl_context.gl.clear_color(0.0, 0.0, 0.0, progress);
+                self.gl_context.gl.clear(GL::COLOR_BUFFER_BIT);
 
-            let progress = (timestamp / FADE_TO_BLACK_DURATION).clamp(0.0, 1.0) as f32;
-            self.gl.clear_color(0.0, 0.0, 0.0, progress);
-            self.gl.clear(GL::COLOR_BUFFER_BIT);
-
-            self.gl
-                .bind_framebuffer(GL::FRAMEBUFFER, Some(self.dxgi_interop.fbo));
-
-            self.flux.render();
-
-            self.gl.bind_framebuffer(GL::FRAMEBUFFER, None);
-
-            self.gl.finish();
-
-            (self.dxgi_interop.dx_interop.DXUnlockObjectsNV)(
-                self.dxgi_interop.gl_handle_d3d,
-                1,
-                &mut self.dxgi_interop.color_handle_gl as *mut _,
-            );
-
-            let _ = self.dxgi_interop.swap_chain.Present(1, 0);
+                self.gl_context.gl.bind_framebuffer(GL::FRAMEBUFFER, None);
+                self.gl_context.gl.finish();
+            });
         }
     }
 }
@@ -209,7 +171,7 @@ fn init_logging(optional_log_dir: Option<&path::Path>) {
 
 fn run_flux(mode: Mode, config: Config) -> Result<(), String> {
     #[cfg(windows)]
-    set_dpi_awareness()?;
+    platform::windows::dpi_awareness::set_dpi_awareness()?;
 
     // By default, SDL disables the screensaver and doesn’t allow the display to sleep. We want
     // both of these things to happen in both screensaver and preview modes.
@@ -376,15 +338,19 @@ fn new_preview_window(
     match window.raw_window_handle() {
         #[cfg(target_os = "windows")]
         raw_window_handle::RawWindowHandle::Win32(event_window_handle) => {
-            if unsafe { set_window_parent_win32(HWND(event_window_handle.hwnd as _), preview_hwnd) }
-            {
+            if unsafe {
+                platform::windows::window::set_window_parent_win32(
+                    HWND(event_window_handle.hwnd as _),
+                    preview_hwnd,
+                )
+            } {
                 log::debug!("Linked preview window");
             }
         }
         _ => (),
     }
 
-    let (gl_context, gl_surface, glow_context, dxgi_interop) = new_gl_context(
+    let gl_context = gl_context::new_gl_context(
         window.raw_display_handle(),
         raw_window_handle,
         inner_size,
@@ -401,7 +367,7 @@ fn new_preview_window(
     let logical_size = physical_size.to_logical(scale_factor);
     let settings = config.to_settings(wallpaper);
     let flux = Flux::new(
-        &glow_context,
+        &gl_context.gl,
         logical_size.width,
         logical_size.height,
         physical_size.width,
@@ -410,14 +376,28 @@ fn new_preview_window(
     )
     .map_err(|err| err.to_string())?;
 
+    #[cfg(windows)]
+    {
+        log::debug!("Creating DXGI swapchain");
+        let dxgi_interop = platform::windows::dxgi_swapchain::create_dxgi_swapchain(
+            &raw_window_handle,
+            &gl_context.gl,
+        );
+        log::debug!("Created DXGI swapchain");
+
+        Ok(Instance {
+            flux,
+            gl_context,
+            window,
+            dxgi_interop,
+        })
+    }
+
+    #[cfg(not(windows))]
     Ok(Instance {
         flux,
         gl_context,
-        gl_surface,
-        gl: Rc::clone(&glow_context),
-        gl_window: None,
         window,
-        dxgi_interop,
     })
 }
 
@@ -437,7 +417,10 @@ fn new_instance(
         .build()
         .map_err(|err| err.to_string())?;
 
-    unsafe { enable_transparency(&window.raw_window_handle()) };
+    #[cfg(windows)]
+    unsafe {
+        platform::windows::window::enable_transparency(&window.raw_window_handle())
+    };
 
     let hidden_window = video_subsystem
         .window("GL Context Window", 1, 1)
@@ -446,7 +429,7 @@ fn new_instance(
         .build()
         .map_err(|err| err.to_string())?;
 
-    let (gl_context, gl_surface, glow_context, dxgi_interop) = new_gl_context(
+    let gl_context = gl_context::new_gl_context(
         window.raw_display_handle(),
         window.raw_window_handle(),
         window.size().into(),
@@ -458,7 +441,7 @@ fn new_instance(
     let logical_size = physical_size.to_logical(surface.scale_factor);
     let settings = config.to_settings(surface.wallpaper.clone());
     let flux = Flux::new(
-        &glow_context,
+        &Rc::clone(&gl_context.gl),
         logical_size.width,
         logical_size.height,
         physical_size.width,
@@ -467,629 +450,27 @@ fn new_instance(
     )
     .map_err(|err| err.to_string())?;
 
+    #[cfg(windows)]
+    {
+        log::debug!("Creating DXGI swapchain");
+        let dxgi_interop = platform::windows::dxgi_swapchain::create_dxgi_swapchain(
+            &window.raw_window_handle(),
+            &gl_context.gl,
+        );
+        log::debug!("Created DXGI swapchain");
+
+        Ok(Instance {
+            flux,
+            gl_context,
+            window,
+            dxgi_interop,
+        })
+    }
+
+    #[cfg(not(windows))]
     Ok(Instance {
         flux,
         gl_context,
-        gl_surface,
-        gl: Rc::clone(&glow_context),
-        gl_window: Some(hidden_window),
         window,
-        dxgi_interop,
     })
-}
-
-/// Create an OpenGL context, surface, and initialize the glow API.
-///
-/// Hacks
-///
-/// The optional attr_window should be used when rendering to the preview window. Instead of just
-/// using the handle to the preview window, pass the window handle for the invisible event window
-/// to work around a bug where Windows complains that it can't find the window class.
-///
-/// This code has been modified from glutin-winit and only supports WGL (Windows).
-fn new_gl_context(
-    raw_display_handle: RawDisplayHandle,
-    actual_raw_window_handle: RawWindowHandle,
-    inner_size: PhysicalSize<u32>,
-
-    hidden_window: Option<RawWindowHandle>,
-    // A hack to create the gl_display using the invisible event window
-    // we create for the preview.
-    attr_window: Option<RawWindowHandle>,
-) -> (
-    PossiblyCurrentContext,
-    Surface<WindowSurface>,
-    Rc<glow::Context>,
-    DXGIInterop,
-) {
-    use glutin::config::ConfigSurfaceTypes;
-
-    let raw_window_handle = hidden_window.unwrap();
-
-    let template = ConfigTemplateBuilder::new()
-        .with_buffer_type(glutin::config::ColorBufferType::Rgb {
-            r_size: 8,
-            g_size: 8,
-            b_size: 8,
-        })
-        .with_alpha_size(8)
-        .with_transparency(true)
-        .compatible_with_native_window(raw_window_handle)
-        // .with_surface_type(ConfigSurfaceTypes::empty())
-        .build();
-
-    // Only WGL requires a window to create a full-fledged OpenGL context
-    let attr_window = attr_window.unwrap_or(raw_window_handle);
-    let preference = DisplayApiPreference::WglThenEgl(Some(attr_window));
-    let gl_display = unsafe { Display::new(raw_display_handle, preference).unwrap() };
-
-    // Rank the configs by transparency and alpha size, while prefering the original order of the
-    // configs.
-    #[derive(Debug, Eq, Ord, PartialEq, PartialOrd)]
-    struct Rank {
-        supports_transparency: bool,
-        alpha_size: u8,
-        samples: i8,
-        prefer_original_order: isize,
-    }
-
-    let (gl_config_index, gl_config) = unsafe {
-        gl_display
-            .find_configs(template)
-            .unwrap()
-            .enumerate()
-            .map(|(index, config)| {
-                log::debug!("Found config #{index}:\n{}", HumanConfig::new(&config));
-                (index, config)
-            })
-            .max_by_key(|(index, config)| Rank {
-                supports_transparency: config.supports_transparency().unwrap_or(false),
-                alpha_size: config.alpha_size(),
-                samples: -(config.num_samples() as i8),
-                prefer_original_order: -(*index as isize),
-            })
-            .expect("cannot find a suitable GL config")
-    };
-
-    log::debug!(
-        "Picked config #{gl_config_index}:\n{}",
-        HumanConfig::new(&gl_config)
-    );
-
-    // Request the minimum required OpenGL version for Flux
-    let context_attributes = ContextAttributesBuilder::new()
-        .with_context_api(ContextApi::OpenGl(Some(Version::new(3, 3))))
-        .build(Some(raw_window_handle));
-
-    // Fallback to GLES 3.0 (aka WebGL 2.0)
-    let fallback_context_attributes = ContextAttributesBuilder::new()
-        .with_context_api(ContextApi::Gles(Some(Version::new(3, 0))))
-        .build(Some(raw_window_handle));
-
-    let not_current_gl_context = unsafe {
-        gl_display
-            .create_context(&gl_config, &context_attributes)
-            .unwrap_or_else(|_| {
-                gl_display
-                    .create_context(&gl_config, &fallback_context_attributes)
-                    .expect("failed to create OpenGL context")
-            })
-    };
-
-    let (width, height) = inner_size.non_zero().expect("non-zero window size").into();
-    let attrs =
-        SurfaceAttributesBuilder::<WindowSurface>::new().build(raw_window_handle, width, height);
-    // ContextAttributesBuilder::new().build(Some(raw_window_handle));
-
-    let gl_surface = unsafe {
-        gl_config
-            .display()
-            // .create_context(&gl_config, &attrs)
-            .create_window_surface(&gl_config, &attrs)
-            .unwrap()
-    };
-
-    // Make it current.
-    let gl_context = not_current_gl_context.make_current(&gl_surface).unwrap();
-
-    // Try setting vsync.
-    // if let Err(res) =
-    //     gl_surface.set_swap_interval(&gl_context, SwapInterval::Wait(NonZeroU32::new(1).unwrap()))
-    // {
-    //     log::error!("Failed to set vsync: {res:?}");
-    // }
-
-    let glow_context = unsafe {
-        glow::Context::from_loader_function(|s| {
-            gl_display.get_proc_address(&CString::new(s).unwrap().as_c_str()) as *const _
-        })
-    };
-    log::debug!("{:?}", glow_context.version());
-
-    // use glutin::display::GetDisplayExtensions;
-    // let extensions = match gl_display {
-    //     Display::Wgl(ref wgl) => wgl.extensions(),
-    //     _ => panic!("Unsupported display"),
-    // };
-
-    log::debug!("Creating DXGI swapchain");
-    let dxgi_interop = create_dxgi_swapchain(
-        &actual_raw_window_handle,
-        &glow_context,
-        width.into(),
-        height.into(),
-    );
-    log::debug!("Created DXGI swapchain");
-
-    // Set common GL state
-    unsafe {
-        glow_context.disable(GL::MULTISAMPLE);
-    }
-
-    (gl_context, gl_surface, Rc::new(glow_context), dxgi_interop)
-}
-
-// Specifying DPI awareness in the app manifest does not apply when running in a
-// preview window.
-#[cfg(windows)]
-pub fn set_dpi_awareness() -> Result<(), String> {
-    use windows::Win32::Foundation::E_INVALIDARG;
-    use windows::Win32::UI::HiDpi::{
-        GetProcessDpiAwareness, SetProcessDpiAwareness, PROCESS_PER_MONITOR_DPI_AWARE,
-        PROCESS_SYSTEM_DPI_AWARE,
-    };
-
-    if let Err(err) = unsafe { SetProcessDpiAwareness(PROCESS_PER_MONITOR_DPI_AWARE) } {
-        match err.code() {
-            E_INVALIDARG => return Err("Can’t enable support for high-resolution screens.".to_string()),
-            // The app manifest settings, if applied, trigger this path.
-            _ => {
-                return match unsafe { GetProcessDpiAwareness(None) } {
-                    Ok(awareness)
-                        if awareness == PROCESS_PER_MONITOR_DPI_AWARE
-                        || awareness == PROCESS_SYSTEM_DPI_AWARE => Ok(()),
-                    _ => Err("Can’t enable support for high-resolution screens. The setting has been modified and set to an unsupported value.".to_string()),
-                }
-            }
-        }
-    }
-
-    Ok(())
-}
-
-#[cfg(windows)]
-unsafe fn set_window_parent_win32(handle: HWND, parent_handle: HWND) -> bool {
-    use windows::Win32::UI::WindowsAndMessaging::{
-        GetWindowLongW, SetParent, SetWindowLongPtrA, GWL_STYLE, WINDOW_STYLE, WS_CHILD, WS_POPUP,
-    };
-
-    // Attach our window to the parent window.
-    // You can get more error information with `GetLastError`
-    // https://docs.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-setparent
-    SetParent(handle, parent_handle);
-
-    let style = WINDOW_STYLE(GetWindowLongW(handle, GWL_STYLE) as u32);
-    let new_style = (style & !WS_POPUP) | WS_CHILD;
-
-    // `SetParent` doesn’t actually set the window style flags. `WS_POPUP` and
-    // `WS_CHILD` are mutually exclusive.
-    SetWindowLongPtrA(handle, GWL_STYLE, new_style.0 as isize);
-
-    true
-}
-
-#[cfg(windows)]
-unsafe fn enable_transparency(handle: &RawWindowHandle) {
-    use windows::Win32::Graphics::{
-        Dwm::{DwmEnableBlurBehindWindow, DWM_BB_BLURREGION, DWM_BB_ENABLE, DWM_BLURBEHIND},
-        Gdi::{CreateRectRgn, DeleteObject},
-    };
-
-    let hwnd = match handle {
-        raw_window_handle::RawWindowHandle::Win32(event_window_handle) => {
-            HWND(event_window_handle.hwnd as _)
-        }
-        _ => panic!("This platform is not supported yet"),
-    };
-
-    // Empty region for the blur effect, so the window is fully transparent
-    let region = CreateRectRgn(0, 0, -1, -1);
-
-    let bb = DWM_BLURBEHIND {
-        dwFlags: DWM_BB_ENABLE | DWM_BB_BLURREGION,
-        fEnable: true.into(),
-        hRgnBlur: region,
-        fTransitionOnMaximized: false.into(),
-    };
-    if let Err(err) = DwmEnableBlurBehindWindow(hwnd, &bb) {
-        log::warn!("Failed to set window transparency: {:?}", err);
-    }
-    DeleteObject(region);
-}
-
-/// [`winit::dpi::PhysicalSize<u32>`] non-zero extensions.
-trait NonZeroU32PhysicalSize {
-    /// Converts to non-zero `(width, height)`.
-    fn non_zero(self) -> Option<(NonZeroU32, NonZeroU32)>;
-}
-impl NonZeroU32PhysicalSize for PhysicalSize<u32> {
-    fn non_zero(self) -> Option<(NonZeroU32, NonZeroU32)> {
-        let w = NonZeroU32::new(self.width)?;
-        let h = NonZeroU32::new(self.height)?;
-        Some((w, h))
-    }
-}
-
-#[derive(Debug)]
-struct HumanConfig {
-    color_buffer_type: Option<ColorBufferType>,
-    alpha_size: u8,
-    depth_size: u8,
-    stencil_size: u8,
-    float_pixels: bool,
-    srgb_capable: bool,
-    supports_transparency: bool,
-    num_samples: u8,
-    hardware_accelerated: bool,
-}
-
-impl HumanConfig {
-    fn new(config: &GLConfig) -> Self {
-        Self {
-            color_buffer_type: config.color_buffer_type(),
-            alpha_size: config.alpha_size(),
-            depth_size: config.depth_size(),
-            stencil_size: config.stencil_size(),
-            float_pixels: config.float_pixels(),
-            srgb_capable: config.srgb_capable(),
-            supports_transparency: config.supports_transparency().unwrap_or(false),
-            num_samples: config.num_samples(),
-            hardware_accelerated: config.hardware_accelerated(),
-        }
-    }
-}
-
-impl fmt::Display for HumanConfig {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let HumanConfig {
-            color_buffer_type,
-            alpha_size,
-            depth_size,
-            stencil_size,
-            float_pixels,
-            srgb_capable,
-            supports_transparency,
-            num_samples,
-            hardware_accelerated,
-        } = self;
-        write!(
-            f,
-            "Color buffer type: {color_buffer_type:?}\n\
-               Alpha size: {alpha_size}\n\
-               Depth size: {depth_size}\n\
-               Stencil size: {stencil_size}\n\
-               Float pixels: {float_pixels}\n\
-               sRGB capable: {srgb_capable}\n\
-               Supports transparency: {supports_transparency}\n\
-               Number of samples: {num_samples}\n\
-               Hardware accelerated: {hardware_accelerated}"
-        )
-    }
-}
-
-// https://github.com/Osspial/render_to_dxgi/blob/master/src/main.rs
-// https://github.com/nlguillemot/OpenGL-on-DXGI/blob/master/main.cpp
-fn create_dxgi_swapchain(
-    raw_window_handle: &RawWindowHandle,
-    gl: &glow::Context,
-    width: u32,
-    height: u32,
-) -> DXGIInterop {
-    use windows::core::*;
-    use windows::Win32::Graphics::Direct3D::{
-        D3D_DRIVER_TYPE_HARDWARE, D3D_FEATURE_LEVEL_10_0, D3D_FEATURE_LEVEL_11_0,
-    };
-    use windows::Win32::Graphics::Direct3D11::{
-        D3D11CreateDevice, D3D11CreateDeviceAndSwapChain, ID3D11Device, ID3D11DeviceContext,
-        ID3D11RenderTargetView, ID3D11Texture2D, D3D11_CREATE_DEVICE_FLAG,
-        D3D11_CREATE_DEVICE_PREVENT_INTERNAL_THREADING_OPTIMIZATIONS,
-        D3D11_CREATE_DEVICE_SINGLETHREADED, D3D11_SDK_VERSION,
-    };
-    use windows::Win32::Graphics::Dxgi::Common::{
-        DXGI_FORMAT, DXGI_FORMAT_R8G8B8A8_UNORM, DXGI_FORMAT_R8G8B8A8_UNORM_SRGB, DXGI_MODE_DESC,
-        DXGI_MODE_SCALING_UNSPECIFIED, DXGI_MODE_SCANLINE_ORDER_UNSPECIFIED, DXGI_SAMPLE_DESC,
-    };
-    use windows::Win32::Graphics::Dxgi::{
-        CreateDXGIFactory2, IDXGIFactory2, IDXGISwapChain, IDXGISwapChain2, DXGI_SWAP_CHAIN_DESC,
-        DXGI_SWAP_CHAIN_DESC1, DXGI_SWAP_CHAIN_FLAG_ALLOW_TEARING,
-        DXGI_SWAP_CHAIN_FLAG_FRAME_LATENCY_WAITABLE_OBJECT, DXGI_SWAP_EFFECT_DISCARD,
-        DXGI_SWAP_EFFECT_FLIP_DISCARD, DXGI_SWAP_EFFECT_FLIP_SEQUENTIAL, DXGI_USAGE_BACK_BUFFER,
-        DXGI_USAGE_RENDER_TARGET_OUTPUT, DXGI_USAGE_UNORDERED_ACCESS,
-    };
-
-    let win32_handle = match raw_window_handle {
-        RawWindowHandle::Win32(handle) => handle,
-        _ => panic!("This platform is not supported yet"),
-    };
-
-    let hwnd = HWND(win32_handle.hwnd as _);
-
-    let mut p_device: Option<ID3D11Device> = None;
-    let mut p_context: Option<ID3D11DeviceContext> = None;
-    let mut p_swap_chain: Option<IDXGISwapChain> = None;
-
-    unsafe {
-        D3D11CreateDeviceAndSwapChain(
-            None,
-            D3D_DRIVER_TYPE_HARDWARE,
-            None,
-            D3D11_CREATE_DEVICE_PREVENT_INTERNAL_THREADING_OPTIMIZATIONS
-                | D3D11_CREATE_DEVICE_FLAG(0)
-                | D3D11_CREATE_DEVICE_SINGLETHREADED,
-            // D3D11_CREATE_DEVICE_FLAG(0), // | D3D11_CREATE_DEVICE_DEBUG,
-            // Some(&[D3D_FEATURE_LEVEL_10_0, D3D_FEATURE_LEVEL_11_0]),
-            Some(&[D3D_FEATURE_LEVEL_11_0]),
-            // None,
-            D3D11_SDK_VERSION,
-            Some(&DXGI_SWAP_CHAIN_DESC {
-                BufferDesc: DXGI_MODE_DESC {
-                    Format: DXGI_FORMAT_R8G8B8A8_UNORM,
-                    // Format: DXGI_FORMAT_B8G8R8A8_UNORM,
-                    // Format: DXGI_FORMAT_B8G8R8A8_UNORM,
-                    // ScanlineOrdering: DXGI_MODE_SCANLINE_ORDER_UNSPECIFIED,
-                    // Scaling: DXGI_MODE_SCALING_UNSPECIFIED,
-                    ..Default::default()
-                },
-                BufferUsage: DXGI_USAGE_RENDER_TARGET_OUTPUT,
-                // | DXGI_USAGE_BACK_BUFFER
-                // | DXGI_USAGE_UNORDERED_ACCESS,
-                BufferCount: 2,
-                OutputWindow: hwnd,
-                Windowed: true.into(),
-                SwapEffect: DXGI_SWAP_EFFECT_FLIP_DISCARD,
-                // SwapEffect: DXGI_SWAP_EFFECT_DISCARD,
-                SampleDesc: DXGI_SAMPLE_DESC {
-                    Count: 1,
-                    Quality: 0,
-                },
-                // Flags: DXGI_SWAP_CHAIN_FLAG_FRAME_LATENCY_WAITABLE_OBJECT.0 as u32,
-                Flags: (DXGI_SWAP_CHAIN_FLAG_FRAME_LATENCY_WAITABLE_OBJECT.0
-                    | DXGI_SWAP_CHAIN_FLAG_ALLOW_TEARING.0) as u32,
-                ..Default::default()
-            }),
-            Some(&mut p_swap_chain),
-            Some(&mut p_device),
-            None,
-            Some(&mut p_context),
-        )
-        .expect("Failed to create DXGI device and swapchain");
-    }
-
-    let swap_chain = p_swap_chain.expect("failed to created swapchain");
-    let context = p_context.expect("failed to create immediate context");
-    let device = p_device.clone().expect("failed to create device");
-
-    log::debug!("Created device, context, and swapchain");
-
-    let swap_chain_2: IDXGISwapChain2 = swap_chain.cast().expect("failed to cast the SwapChain");
-
-    let frame_latency_waitable_object = unsafe { swap_chain_2.GetFrameLatencyWaitableObject() };
-
-    use std::borrow::Cow;
-    use std::ffi::CStr;
-    use windows::core::PCSTR;
-    use windows::Win32::Graphics::Gdi::HDC;
-    use windows::Win32::Graphics::OpenGL::{wglGetCurrentDC, wglGetProcAddress};
-
-    unsafe {
-        let dc = wglGetCurrentDC();
-        let get_extensions_string_arb: Option<unsafe extern "C" fn(hdc: HDC) -> *const c_char> =
-            mem::transmute(wglGetProcAddress(PCSTR(
-                &b"wglGetExtensionsStringARB\0"[0] as *const u8,
-            )));
-
-        let extensions = match get_extensions_string_arb {
-            Some(wglGetExtensionsStringARB) => {
-                CStr::from_ptr(wglGetExtensionsStringARB(dc)).to_string_lossy()
-            }
-            None => Cow::Borrowed(""),
-        };
-
-        // Load function pointers.
-        for extension in extensions.split(' ') {
-            if extension == "WGL_NV_DX_interop" {
-                log::debug!("Found WGL_NV_DX_interop");
-            }
-            if extension == "WGL_NV_DX_interop2" {
-                log::debug!("Found WGL_NV_DX_interop2");
-            }
-        }
-
-        log::debug!("Extensions: {}", extensions);
-    }
-
-    let dx_interop = unsafe {
-        WGLDXInteropExtensionFunctions {
-            DXCloseDeviceNV: mem::transmute(wglGetProcAddress(PCSTR(
-                &b"wglDXCloseDeviceNV\0"[0] as *const u8,
-            ))),
-            DXLockObjectsNV: mem::transmute(wglGetProcAddress(PCSTR(
-                &b"wglDXLockObjectsNV\0"[0] as *const u8,
-            ))),
-            DXOpenDeviceNV: mem::transmute(wglGetProcAddress(PCSTR(
-                &b"wglDXOpenDeviceNV\0"[0] as *const u8,
-            ))),
-            DXRegisterObjectNV: mem::transmute(wglGetProcAddress(PCSTR(
-                &b"wglDXRegisterObjectNV\0"[0] as *const u8,
-            ))),
-            DXSetResourceShareHandleNV: mem::transmute(wglGetProcAddress(PCSTR(
-                &b"wglDXSetResourceShareHandleNV\0"[0] as *const u8,
-            ))),
-            DXUnlockObjectsNV: mem::transmute(wglGetProcAddress(PCSTR(
-                &b"wglDXUnlockObjectsNV\0"[0] as *const u8,
-            ))),
-            DXUnregisterObjectNV: mem::transmute(wglGetProcAddress(PCSTR(
-                &b"wglDXUnregisterObjectNV\0"[0] as *const u8,
-            ))),
-        }
-    };
-    log::debug!("Fetched interop extension functions");
-
-    unsafe {
-        let gl_handle_d3d = (dx_interop.DXOpenDeviceNV)(device.as_raw());
-        if gl_handle_d3d.is_invalid() {
-            log::error!("Failed to open the GL DX interop device");
-        } else {
-            log::debug!("Opened interop device");
-        }
-
-        let mut color_buffer: ID3D11Texture2D = swap_chain_2.GetBuffer(0).unwrap();
-        let mut color_buffer_view: Option<ID3D11RenderTargetView> = None;
-
-        // let desc = D3D11_RENDER_TARGET_VIEW_DESC {
-        //     Format: DXGI_FORMAT_R8G8B8A8_UNORM,
-        //     Usage: D3D11_USAGE_DEFAULT,
-        //     ..Default::default()
-        // };
-
-        device
-            .CreateRenderTargetView(&color_buffer, None, Some(&mut color_buffer_view))
-            .unwrap();
-
-        context.OMSetRenderTargets(Some(&[color_buffer_view.clone()]), None);
-        let clear_color: [f32; 4] = [0.0, 0.0, 0.0, 0.0];
-        context.ClearRenderTargetView(
-            color_buffer_view.as_ref().unwrap(),
-            &clear_color as *const _,
-        );
-        log::debug!("Cleared render target view");
-
-        let rbo = gl.create_renderbuffer().unwrap();
-        let fbo = gl.create_framebuffer().unwrap();
-        let texture = gl.create_texture().unwrap();
-
-        // I don't think this is necessary, at least according to the khronos example
-        // gl.bind_renderbuffer(GL::RENDERBUFFER, Some(rbo));
-        // gl.renderbuffer_storage(GL::RENDERBUFFER, GL::RGBA8, width as i32, height as i32);
-        // gl.bind_renderbuffer(GL::RENDERBUFFER, None);
-
-        log::debug!("Created GL renderbuffer");
-
-        const WGL_ACCESS_READ_WRITE_NV: u32 = 0x0001;
-        const WGL_ACCESS_READ_WRITE_DISCARD_NV: u32 = 0x0002;
-        // let color_handle_gl = (dx_interop.DXRegisterObjectNV)(
-        //     gl_handle_d3d,
-        //     color_buffer.as_raw(),
-        //     rbo.0.into(),
-        //     GL::RENDERBUFFER,
-        //     WGL_ACCESS_READ_WRITE_DISCARD_NV,
-        // );
-
-        // According to my testing, AMD graphics cards don't support sharing renderbuffers.
-        let color_handle_gl = (dx_interop.DXRegisterObjectNV)(
-            gl_handle_d3d,
-            color_buffer.as_raw(),
-            texture.0.into(),
-            GL::TEXTURE_2D,
-            WGL_ACCESS_READ_WRITE_DISCARD_NV,
-        );
-
-        if color_handle_gl.is_invalid() {
-            log::error!("Failed to register color buffer handle");
-        } else {
-            log::debug!("Registered color buffer");
-        }
-
-        // Bind the texture to the framebuffer
-        gl.bind_framebuffer(GL::FRAMEBUFFER, Some(fbo));
-        gl.framebuffer_texture_2d(
-            GL::FRAMEBUFFER,
-            GL::COLOR_ATTACHMENT0,
-            GL::TEXTURE_2D,
-            Some(texture),
-            0,
-        );
-
-        // gl.viewport(0, 0, width as i32, height as i32);
-        // gl.bind_renderbuffer(GL::RENDERBUFFER, Some(rbo));
-        // gl.bind_framebuffer(GL::FRAMEBUFFER, Some(fbo));
-        // gl.framebuffer_renderbuffer(
-        //     GL::FRAMEBUFFER,
-        //     GL::COLOR_ATTACHMENT0,
-        //     GL::RENDERBUFFER,
-        //     Some(rbo),
-        // );
-        log::debug!("Created GL framebuffer");
-
-        match gl.check_framebuffer_status(GL::FRAMEBUFFER) {
-            GL::FRAMEBUFFER_INCOMPLETE_ATTACHMENT => {
-                log::error!("FRAMEBUFFER_INCOMPLETE_ATTACHMENT")
-            }
-            GL::FRAMEBUFFER_INCOMPLETE_MISSING_ATTACHMENT => {
-                log::error!("FRAMEBUFFER_INCOMPLETE_MISSING_ATTACHMENT")
-            }
-            GL::FRAMEBUFFER_COMPLETE => {
-                log::debug!("FRAMEBUFFER_COMPLETE");
-            }
-            other => log::debug!("Framebuffer status: {:#x}", other),
-        }
-
-        gl.bind_framebuffer(GL::FRAMEBUFFER, None);
-
-        DXGIInterop {
-            device,
-            context,
-            swap_chain: swap_chain_2,
-            gl_handle_d3d,
-            dx_interop,
-            color_handle_gl,
-            frame_latency_waitable_object,
-            fbo,
-            rbo,
-        }
-    }
-}
-
-use windows::Win32::Graphics::Direct3D11::ID3D11RenderTargetView;
-use windows::Win32::Graphics::Direct3D11::{
-    ID3D11Device, ID3D11DeviceContext, D3D11_CREATE_DEVICE_DEBUG,
-};
-use windows::Win32::Graphics::Dxgi::IDXGISwapChain2;
-
-struct DXGIInterop {
-    device: ID3D11Device,
-    context: ID3D11DeviceContext,
-    // swap_chain: IDXGISwapChain,
-    swap_chain: IDXGISwapChain2,
-    gl_handle_d3d: HANDLE,
-    dx_interop: WGLDXInteropExtensionFunctions,
-    color_handle_gl: HANDLE,
-    frame_latency_waitable_object: HANDLE,
-    fbo: GL::NativeFramebuffer,
-    rbo: GL::NativeRenderbuffer,
-}
-
-use std::os::raw::{c_char, c_int, c_uint, c_void};
-use windows::Win32::Foundation::{BOOL, HANDLE};
-type GLint = c_int;
-type GLenum = c_uint;
-type GLuint = c_uint;
-#[allow(non_snake_case)]
-pub(crate) struct WGLDXInteropExtensionFunctions {
-    pub(crate) DXCloseDeviceNV: unsafe extern "C" fn(hDevice: HANDLE) -> BOOL,
-    pub(crate) DXLockObjectsNV:
-        unsafe extern "C" fn(hDevice: HANDLE, count: GLint, hObjects: *mut HANDLE) -> BOOL,
-    pub(crate) DXOpenDeviceNV: unsafe extern "C" fn(dxDevice: *mut c_void) -> HANDLE,
-    pub(crate) DXRegisterObjectNV: unsafe extern "C" fn(
-        hDevice: HANDLE,
-        dxResource: *mut c_void,
-        name: GLuint,
-        object_type: GLenum,
-        access: GLenum,
-    ) -> HANDLE,
-    pub(crate) DXSetResourceShareHandleNV:
-        unsafe extern "C" fn(dxResource: *mut c_void, shareHandle: HANDLE) -> BOOL,
-    pub(crate) DXUnlockObjectsNV:
-        unsafe extern "C" fn(hDevice: HANDLE, count: GLint, hObjects: *mut HANDLE) -> BOOL,
-    pub(crate) DXUnregisterObjectNV: unsafe extern "C" fn(hDevice: HANDLE, hObject: HANDLE) -> BOOL,
 }

--- a/windows/src/main.rs
+++ b/windows/src/main.rs
@@ -427,10 +427,7 @@ fn new_gl_context(
             b_size: 8,
         })
         .with_alpha_size(8)
-        .with_depth_size(0)
-        .with_stencil_size(0)
         .with_transparency(true)
-        .with_multisampling(0)
         .compatible_with_native_window(raw_window_handle)
         .build();
 

--- a/windows/src/platform/mod.rs
+++ b/windows/src/platform/mod.rs
@@ -1,0 +1,2 @@
+#[cfg(windows)]
+pub mod windows;

--- a/windows/src/platform/windows/dpi_awareness.rs
+++ b/windows/src/platform/windows/dpi_awareness.rs
@@ -1,0 +1,26 @@
+// Specifying DPI awareness in the app manifest does not apply when running in a
+// preview window.
+pub fn set_dpi_awareness() -> Result<(), String> {
+    use windows::Win32::Foundation::E_INVALIDARG;
+    use windows::Win32::UI::HiDpi::{
+        GetProcessDpiAwareness, SetProcessDpiAwareness, PROCESS_PER_MONITOR_DPI_AWARE,
+        PROCESS_SYSTEM_DPI_AWARE,
+    };
+
+    if let Err(err) = unsafe { SetProcessDpiAwareness(PROCESS_PER_MONITOR_DPI_AWARE) } {
+        match err.code() {
+            E_INVALIDARG => return Err("Can’t enable support for high-resolution screens.".to_string()),
+            // The app manifest settings, if applied, trigger this path.
+            _ => {
+                return match unsafe { GetProcessDpiAwareness(None) } {
+                    Ok(awareness)
+                        if awareness == PROCESS_PER_MONITOR_DPI_AWARE
+                        || awareness == PROCESS_SYSTEM_DPI_AWARE => Ok(()),
+                    _ => Err("Can’t enable support for high-resolution screens. The setting has been modified and set to an unsupported value.".to_string()),
+                }
+            }
+        }
+    }
+
+    Ok(())
+}

--- a/windows/src/platform/windows/dxgi_swapchain.rs
+++ b/windows/src/platform/windows/dxgi_swapchain.rs
@@ -242,7 +242,12 @@ pub(crate) fn create_dxgi_swapchain(
         // Register the D3D11 device with GL
         let gl_handle_d3d = (dx_interop.DXOpenDeviceNV)(device.as_raw());
         if gl_handle_d3d.is_invalid() {
-            return Err("Failed to open the GL DX interop device".into());
+            let msg = std::io::Error::last_os_error();
+            return Err(format!(
+                "Failed to open the GL DX interop device. OS Error: {:?}",
+                msg
+            )
+            .into());
         }
 
         log::debug!("Opened GL DX interop device");
@@ -274,7 +279,10 @@ pub(crate) fn create_dxgi_swapchain(
             );
 
             if color_handle_gl.is_invalid() {
-                return Err("Failed to register texture with DXGI.".into());
+                let msg = std::io::Error::last_os_error();
+                return Err(
+                    format!("Failed to register texture with DXGI. OS Error: {:?}", msg).into(),
+                );
             }
 
             log::debug!("Registered DXGI swapchain as GL texture");

--- a/windows/src/platform/windows/dxgi_swapchain.rs
+++ b/windows/src/platform/windows/dxgi_swapchain.rs
@@ -1,0 +1,325 @@
+use std::borrow::Cow;
+use std::ffi::CStr;
+use std::mem;
+use std::os::raw::{c_char, c_int, c_uint, c_void};
+
+use glow as GL;
+use glow::HasContext;
+use raw_window_handle::RawWindowHandle;
+
+use windows::core::*;
+use windows::Win32::Foundation::{BOOL, HANDLE, HWND};
+use windows::Win32::Graphics::Direct3D::{D3D_DRIVER_TYPE_HARDWARE, D3D_FEATURE_LEVEL_11_0};
+use windows::Win32::Graphics::Direct3D11::{
+    D3D11CreateDeviceAndSwapChain, ID3D11Device, ID3D11DeviceContext, ID3D11RenderTargetView,
+    ID3D11Texture2D, D3D11_CREATE_DEVICE_FLAG,
+    D3D11_CREATE_DEVICE_PREVENT_INTERNAL_THREADING_OPTIMIZATIONS,
+    D3D11_CREATE_DEVICE_SINGLETHREADED, D3D11_SDK_VERSION,
+};
+use windows::Win32::Graphics::Dxgi::Common::{
+    DXGI_FORMAT_R8G8B8A8_UNORM, DXGI_MODE_DESC, DXGI_SAMPLE_DESC,
+};
+use windows::Win32::Graphics::Dxgi::{
+    IDXGISwapChain, IDXGISwapChain2, DXGI_SWAP_CHAIN_DESC, DXGI_SWAP_CHAIN_FLAG_ALLOW_TEARING,
+    DXGI_SWAP_CHAIN_FLAG_FRAME_LATENCY_WAITABLE_OBJECT, DXGI_SWAP_EFFECT_FLIP_DISCARD,
+    DXGI_USAGE_RENDER_TARGET_OUTPUT,
+};
+use windows::Win32::Graphics::Gdi::HDC;
+use windows::Win32::Graphics::OpenGL::{wglGetCurrentDC, wglGetProcAddress};
+
+pub(crate) struct DXGIInterop {
+    device: ID3D11Device,
+    context: ID3D11DeviceContext,
+    swap_chain: IDXGISwapChain2,
+    gl_handle_d3d: HANDLE,
+    dx_interop: WGLDXInteropExtensionFunctions,
+    color_handle_gl: HANDLE,
+    frame_latency_waitable_object: HANDLE,
+    fbo: GL::NativeFramebuffer,
+    rbo: GL::NativeRenderbuffer,
+}
+
+type GLint = c_int;
+type GLenum = c_uint;
+type GLuint = c_uint;
+
+#[allow(non_snake_case)]
+pub(crate) struct WGLDXInteropExtensionFunctions {
+    pub(crate) DXCloseDeviceNV: unsafe extern "C" fn(hDevice: HANDLE) -> BOOL,
+    pub(crate) DXLockObjectsNV:
+        unsafe extern "C" fn(hDevice: HANDLE, count: GLint, hObjects: *mut HANDLE) -> BOOL,
+    pub(crate) DXOpenDeviceNV: unsafe extern "C" fn(dxDevice: *mut c_void) -> HANDLE,
+    pub(crate) DXRegisterObjectNV: unsafe extern "C" fn(
+        hDevice: HANDLE,
+        dxResource: *mut c_void,
+        name: GLuint,
+        object_type: GLenum,
+        access: GLenum,
+    ) -> HANDLE,
+    pub(crate) DXSetResourceShareHandleNV:
+        unsafe extern "C" fn(dxResource: *mut c_void, shareHandle: HANDLE) -> BOOL,
+    pub(crate) DXUnlockObjectsNV:
+        unsafe extern "C" fn(hDevice: HANDLE, count: GLint, hObjects: *mut HANDLE) -> BOOL,
+    pub(crate) DXUnregisterObjectNV: unsafe extern "C" fn(hDevice: HANDLE, hObject: HANDLE) -> BOOL,
+}
+
+pub(crate) unsafe fn with_dxgi_swapchain(
+    dxgi_interop: &mut DXGIInterop,
+    render: impl FnOnce(&GL::NativeFramebuffer),
+) {
+    use windows::Win32::System::Threading::{WaitForSingleObject, INFINITE};
+    WaitForSingleObject(dxgi_interop.frame_latency_waitable_object, INFINITE);
+
+    (dxgi_interop.dx_interop.DXLockObjectsNV)(
+        dxgi_interop.gl_handle_d3d,
+        1,
+        &mut dxgi_interop.color_handle_gl as *mut _,
+    );
+
+    (dxgi_interop.dx_interop.DXUnlockObjectsNV)(
+        dxgi_interop.gl_handle_d3d,
+        1,
+        &mut dxgi_interop.color_handle_gl as *mut _,
+    );
+
+    render(&dxgi_interop.fbo);
+
+    let _ = dxgi_interop.swap_chain.Present(1, 0);
+}
+
+// https://github.com/Osspial/render_to_dxgi/blob/master/src/main.rs
+// https://github.com/nlguillemot/OpenGL-on-DXGI/blob/master/main.cpp
+#[allow(non_snake_case)]
+pub(crate) fn create_dxgi_swapchain(
+    raw_window_handle: &RawWindowHandle,
+    gl: &glow::Context,
+) -> DXGIInterop {
+    let win32_handle = match raw_window_handle {
+        RawWindowHandle::Win32(handle) => handle,
+        _ => panic!("This platform is not supported yet"),
+    };
+
+    let hwnd = HWND(win32_handle.hwnd as _);
+
+    let mut p_device: Option<ID3D11Device> = None;
+    let mut p_context: Option<ID3D11DeviceContext> = None;
+    let mut p_swap_chain: Option<IDXGISwapChain> = None;
+
+    unsafe {
+        D3D11CreateDeviceAndSwapChain(
+            None,
+            D3D_DRIVER_TYPE_HARDWARE,
+            None,
+            D3D11_CREATE_DEVICE_PREVENT_INTERNAL_THREADING_OPTIMIZATIONS
+                | D3D11_CREATE_DEVICE_FLAG(0)
+                | D3D11_CREATE_DEVICE_SINGLETHREADED,
+            // D3D11_CREATE_DEVICE_FLAG(0), // | D3D11_CREATE_DEVICE_DEBUG,
+            // Some(&[D3D_FEATURE_LEVEL_10_0, D3D_FEATURE_LEVEL_11_0]),
+            Some(&[D3D_FEATURE_LEVEL_11_0]),
+            // None,
+            D3D11_SDK_VERSION,
+            Some(&DXGI_SWAP_CHAIN_DESC {
+                BufferDesc: DXGI_MODE_DESC {
+                    Format: DXGI_FORMAT_R8G8B8A8_UNORM,
+                    ..Default::default()
+                },
+                BufferUsage: DXGI_USAGE_RENDER_TARGET_OUTPUT,
+                // | DXGI_USAGE_BACK_BUFFER
+                // | DXGI_USAGE_UNORDERED_ACCESS,
+                BufferCount: 2,
+                OutputWindow: hwnd,
+                Windowed: true.into(),
+                SwapEffect: DXGI_SWAP_EFFECT_FLIP_DISCARD,
+                // SwapEffect: DXGI_SWAP_EFFECT_DISCARD,
+                SampleDesc: DXGI_SAMPLE_DESC {
+                    Count: 1,
+                    Quality: 0,
+                },
+                // Flags: DXGI_SWAP_CHAIN_FLAG_FRAME_LATENCY_WAITABLE_OBJECT.0 as u32,
+                Flags: (DXGI_SWAP_CHAIN_FLAG_FRAME_LATENCY_WAITABLE_OBJECT.0
+                    | DXGI_SWAP_CHAIN_FLAG_ALLOW_TEARING.0) as u32,
+                ..Default::default()
+            }),
+            Some(&mut p_swap_chain),
+            Some(&mut p_device),
+            None,
+            Some(&mut p_context),
+        )
+        .expect("Failed to create DXGI device and swapchain");
+    }
+
+    let swap_chain = p_swap_chain.expect("failed to created swapchain");
+    let context = p_context.expect("failed to create immediate context");
+    let device = p_device.clone().expect("failed to create device");
+
+    log::debug!("Created device, context, and swapchain");
+
+    let swap_chain_2: IDXGISwapChain2 = swap_chain.cast().expect("failed to cast the SwapChain");
+
+    let frame_latency_waitable_object = unsafe { swap_chain_2.GetFrameLatencyWaitableObject() };
+
+    unsafe {
+        let dc = wglGetCurrentDC();
+        let get_extensions_string_arb: Option<unsafe extern "C" fn(hdc: HDC) -> *const c_char> =
+            mem::transmute(wglGetProcAddress(PCSTR(
+                &b"wglGetExtensionsStringARB\0"[0] as *const u8,
+            )));
+
+        let extensions = match get_extensions_string_arb {
+            Some(wglGetExtensionsStringARB) => {
+                CStr::from_ptr(wglGetExtensionsStringARB(dc)).to_string_lossy()
+            }
+            None => Cow::Borrowed(""),
+        };
+
+        // Load function pointers.
+        for extension in extensions.split(' ') {
+            if extension == "WGL_NV_DX_interop" {
+                log::debug!("Found WGL_NV_DX_interop");
+            }
+            if extension == "WGL_NV_DX_interop2" {
+                log::debug!("Found WGL_NV_DX_interop2");
+            }
+        }
+
+        log::debug!("Extensions: {}", extensions);
+    }
+
+    // const WGL_ACCESS_READ_WRITE_NV: u32 = 0x0001;
+    const WGL_ACCESS_READ_WRITE_DISCARD_NV: u32 = 0x0002;
+
+    let dx_interop = unsafe {
+        WGLDXInteropExtensionFunctions {
+            DXCloseDeviceNV: mem::transmute(wglGetProcAddress(PCSTR(
+                &b"wglDXCloseDeviceNV\0"[0] as *const u8,
+            ))),
+            DXLockObjectsNV: mem::transmute(wglGetProcAddress(PCSTR(
+                &b"wglDXLockObjectsNV\0"[0] as *const u8,
+            ))),
+            DXOpenDeviceNV: mem::transmute(wglGetProcAddress(PCSTR(
+                &b"wglDXOpenDeviceNV\0"[0] as *const u8,
+            ))),
+            DXRegisterObjectNV: mem::transmute(wglGetProcAddress(PCSTR(
+                &b"wglDXRegisterObjectNV\0"[0] as *const u8,
+            ))),
+            DXSetResourceShareHandleNV: mem::transmute(wglGetProcAddress(PCSTR(
+                &b"wglDXSetResourceShareHandleNV\0"[0] as *const u8,
+            ))),
+            DXUnlockObjectsNV: mem::transmute(wglGetProcAddress(PCSTR(
+                &b"wglDXUnlockObjectsNV\0"[0] as *const u8,
+            ))),
+            DXUnregisterObjectNV: mem::transmute(wglGetProcAddress(PCSTR(
+                &b"wglDXUnregisterObjectNV\0"[0] as *const u8,
+            ))),
+        }
+    };
+    log::debug!("Fetched interop extension functions");
+
+    unsafe {
+        let gl_handle_d3d = (dx_interop.DXOpenDeviceNV)(device.as_raw());
+        if gl_handle_d3d.is_invalid() {
+            log::error!("Failed to open the GL DX interop device");
+        } else {
+            log::debug!("Opened interop device");
+        }
+
+        let color_buffer: ID3D11Texture2D = swap_chain_2.GetBuffer(0).unwrap();
+        let mut color_buffer_view: Option<ID3D11RenderTargetView> = None;
+
+        device
+            .CreateRenderTargetView(&color_buffer, None, Some(&mut color_buffer_view))
+            .unwrap();
+
+        context.OMSetRenderTargets(Some(&[color_buffer_view.clone()]), None);
+        let clear_color: [f32; 4] = [0.0, 0.0, 0.0, 0.0];
+        context.ClearRenderTargetView(
+            color_buffer_view.as_ref().unwrap(),
+            &clear_color as *const _,
+        );
+        log::debug!("Cleared render target view");
+
+        let fbo = gl.create_framebuffer().unwrap();
+
+        log::debug!("Created GL renderbuffer");
+
+        let rbo = gl.create_renderbuffer().unwrap();
+
+        let color_handle_gl = (dx_interop.DXRegisterObjectNV)(
+            gl_handle_d3d,
+            color_buffer.as_raw(),
+            rbo.0.into(),
+            GL::RENDERBUFFER,
+            WGL_ACCESS_READ_WRITE_DISCARD_NV,
+        );
+
+        if color_handle_gl.is_invalid() {
+            log::error!("Failed to register a renderbuffer with DXGI. Falling back to a texture.");
+
+            gl.delete_renderbuffer(rbo);
+            let texture = gl.create_texture().unwrap();
+
+            // According to my testing, AMD graphics cards don't support sharing renderbuffers.
+            let color_handle_gl = (dx_interop.DXRegisterObjectNV)(
+                gl_handle_d3d,
+                color_buffer.as_raw(),
+                texture.0.into(),
+                GL::TEXTURE_2D,
+                WGL_ACCESS_READ_WRITE_DISCARD_NV,
+            );
+
+            if color_handle_gl.is_invalid() {
+                log::error!("Failed to register color buffer handle");
+            }
+
+            log::debug!("Registered texture with DXGI");
+
+            // Bind the texture to the framebuffer
+            gl.bind_framebuffer(GL::FRAMEBUFFER, Some(fbo));
+            gl.framebuffer_texture_2d(
+                GL::FRAMEBUFFER,
+                GL::COLOR_ATTACHMENT0,
+                GL::TEXTURE_2D,
+                Some(texture),
+                0,
+            );
+        } else {
+            log::debug!("Registed renderbuffer with DXGI");
+
+            gl.bind_renderbuffer(GL::RENDERBUFFER, Some(rbo));
+            gl.bind_framebuffer(GL::FRAMEBUFFER, Some(fbo));
+            gl.framebuffer_renderbuffer(
+                GL::FRAMEBUFFER,
+                GL::COLOR_ATTACHMENT0,
+                GL::RENDERBUFFER,
+                Some(rbo),
+            );
+        }
+
+        match gl.check_framebuffer_status(GL::FRAMEBUFFER) {
+            GL::FRAMEBUFFER_INCOMPLETE_ATTACHMENT => {
+                log::error!("DXGI Framebuffer: incomplete attachment")
+            }
+            GL::FRAMEBUFFER_INCOMPLETE_MISSING_ATTACHMENT => {
+                log::error!("DXGI Framebuffer: missing attachment")
+            }
+            GL::FRAMEBUFFER_COMPLETE => {
+                log::debug!("DXGI Framebuffer: complete");
+            }
+            other => log::debug!("DXGI Framebuffer: {:#x}", other),
+        }
+
+        gl.bind_framebuffer(GL::FRAMEBUFFER, None);
+
+        DXGIInterop {
+            device,
+            context,
+            swap_chain: swap_chain_2,
+            gl_handle_d3d,
+            dx_interop,
+            color_handle_gl,
+            frame_latency_waitable_object,
+            fbo,
+            rbo,
+        }
+    }
+}

--- a/windows/src/platform/windows/mod.rs
+++ b/windows/src/platform/windows/mod.rs
@@ -1,0 +1,3 @@
+pub mod dpi_awareness;
+pub mod dxgi_swapchain;
+pub mod window;

--- a/windows/src/platform/windows/window.rs
+++ b/windows/src/platform/windows/window.rs
@@ -1,0 +1,50 @@
+use raw_window_handle::RawWindowHandle;
+use windows::Win32::Foundation::HWND;
+
+pub unsafe fn set_window_parent_win32(handle: HWND, parent_handle: HWND) -> bool {
+    use windows::Win32::UI::WindowsAndMessaging::{
+        GetWindowLongW, SetParent, SetWindowLongPtrA, GWL_STYLE, WINDOW_STYLE, WS_CHILD, WS_POPUP,
+    };
+
+    // Attach our window to the parent window.
+    // You can get more error information with `GetLastError`
+    // https://docs.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-setparent
+    SetParent(handle, parent_handle);
+
+    let style = WINDOW_STYLE(GetWindowLongW(handle, GWL_STYLE) as u32);
+    let new_style = (style & !WS_POPUP) | WS_CHILD;
+
+    // `SetParent` doesn’t actually set the window style flags. `WS_POPUP` and
+    // `WS_CHILD` are mutually exclusive.
+    SetWindowLongPtrA(handle, GWL_STYLE, new_style.0 as isize);
+
+    true
+}
+
+pub unsafe fn enable_transparency(handle: &RawWindowHandle) {
+    use windows::Win32::Graphics::{
+        Dwm::{DwmEnableBlurBehindWindow, DWM_BB_BLURREGION, DWM_BB_ENABLE, DWM_BLURBEHIND},
+        Gdi::{CreateRectRgn, DeleteObject},
+    };
+
+    let hwnd = match handle {
+        raw_window_handle::RawWindowHandle::Win32(event_window_handle) => {
+            HWND(event_window_handle.hwnd as _)
+        }
+        _ => panic!("This platform is not supported yet"),
+    };
+
+    // Empty region for the blur effect, so the window is fully transparent
+    let region = CreateRectRgn(0, 0, -1, -1);
+
+    let bb = DWM_BLURBEHIND {
+        dwFlags: DWM_BB_ENABLE | DWM_BB_BLURREGION,
+        fEnable: true.into(),
+        hRgnBlur: region,
+        fTransitionOnMaximized: false.into(),
+    };
+    if let Err(err) = DwmEnableBlurBehindWindow(hwnd, &bb) {
+        log::warn!("Failed to set window transparency: {:?}", err);
+    }
+    DeleteObject(region);
+}

--- a/windows/src/winit_compat.rs
+++ b/windows/src/winit_compat.rs
@@ -1,5 +1,6 @@
 use std::collections::vec_deque;
 use std::iter::Map;
+use std::num::NonZeroU32;
 
 use sdl2::video::Window;
 use sdl2::VideoSubsystem;
@@ -54,5 +55,18 @@ impl HasMonitors for VideoSubsystem {
         platform::monitor::available_monitors()
             .into_iter()
             .map(|inner| MonitorHandle { inner })
+    }
+}
+
+/// [`winit::dpi::PhysicalSize<u32>`] non-zero extensions.
+pub trait NonZeroU32PhysicalSize {
+    /// Converts to non-zero `(width, height)`.
+    fn non_zero(self) -> Option<(NonZeroU32, NonZeroU32)>;
+}
+impl NonZeroU32PhysicalSize for PhysicalSize<u32> {
+    fn non_zero(self) -> Option<(NonZeroU32, NonZeroU32)> {
+        let w = NonZeroU32::new(self.width)?;
+        let h = NonZeroU32::new(self.height)?;
+        Some((w, h))
     }
 }


### PR DESCRIPTION
Draws to a DXGI swapchain on Windows to work around a bug where Windows permanently disables HDR after running an OpenGL app.

Fixes #17.

### Tested on

- [x] Nvidia (RTX3060 + multiple feedback from a bunch of customers)
- [x] AMD (Radeon Pro 560X Macbook Pro 15-inch via Basecamp)
- [x] Intel (Iris 5100) **Not supported** Falls back to OpenGL swapchain.